### PR TITLE
[IIIF-2] build canteloupe from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cantaloupe.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ VOLUME /imageroot
 
 # Update packages and install tools
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends wget unzip graphicsmagick curl imagemagick libopenjp2-tools ffmpeg python
+    apt-get install -y --no-install-recommends wget unzip graphicsmagick curl imagemagick libopenjp2-tools ffmpeg python && \
     rm -rf /var/lib/apt/lists/* ### this command prevents future tinkering with apt
 
 # Run non privileged

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG CANTALOUPE_VERSION=4.0.2
 FROM maven:3.6.0-jdk-11 AS MAVEN_TOOL_CHAIN
 ARG CANTALOUPE_VERSION
+ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 RUN mkdir -p /build && \
     cd /build && \
     if [ "$CANTALOUPE_VERSION" = 'latest' ] ; then curl -OL https://github.com/medusa-project/cantaloupe/archive/develop.zip; else curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; fi
@@ -11,6 +12,7 @@ RUN if [ "$CANTALOUPE_VERSION" = 'latest' ]; then unzip develop.zip cantaloupe-d
 
 FROM openjdk:10-slim
 ARG CANTALOUPE_VERSION
+ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 
 EXPOSE 8182
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ VOLUME /imageroot
 # Update packages and install tools
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends wget unzip graphicsmagick curl imagemagick libopenjp2-tools ffmpeg python
-    #rm -rf /var/lib/apt/lists/* ### this command prevents future tinkering with apt
+    rm -rf /var/lib/apt/lists/* ### this command prevents future tinkering with apt
 
 # Run non privileged
 RUN adduser --system cantaloupe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
+ARG CANTALOUPE_VERSION=4.0.2
 FROM maven:3.6.0-jdk-11 AS MAVEN_TOOL_CHAIN
+ARG CANTALOUPE_VERSION
 RUN mkdir -p /build && \
     cd /build && \
     if [ "$CANTALOUPE_VERSION" = 'latest' ] ; then curl -OL https://github.com/medusa-project/cantaloupe/archive/develop.zip; else curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; fi
 
 # unzip and compile the Cantaloupe source code if $CANTALOUPE_VERSION = 'latest'
 WORKDIR /build/
-RUN if [ "$CANTALOUPE_VERSION" = 'latest' ]; then unzip develop.zip -d src && cd src && mvn package && cp /build/src/target/Cantaloupe-$CANTALOUPE_VERSION.zip /build/Cantaloupe-$CANTALOUPE_VERSION.zip; fi
+RUN if [ "$CANTALOUPE_VERSION" = 'latest' ]; then unzip develop.zip cantaloupe-develop/* && mv cantaloupe-develop src && cd src/ && cp test.properties.sample test.properties && mvn -Pfreedeps -DskipTests clean package && cp /build/src/target/cantaloupe-?.?-SNAPSHOT.zip /build/Cantaloupe-$CANTALOUPE_VERSION.zip; fi
 
 FROM openjdk:10-slim
-
 ARG CANTALOUPE_VERSION
-#ENV CANTALOUPE_VERSION=4.0.2
-#ENV IMAGEMAGICK_VERSION=7.0.8-14
 
 EXPOSE 8182
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This invocation will download the 4.0.2 (current at time of writing) release of 
 
     docker build --build-arg CANTALOUPE_VERSION=<desired version> -t cantaloupe .
 
+To build the latest version of Cantaloupe from source, use the following:
+
+    docker build --build-arg CANTALOUPE_VERSION=latest -t cantaloupe .
+
+
 ### Run the container
 
  First you will need to set the environment variables required to run Cantaloupe. If you would like to test additional settings, ensure the cantaloupe.propoerties.tmpl template has the variable configured or you have set it as an environment variable.


### PR DESCRIPTION
Utilizing a multi-stage build, the first stage either downloads the release .zip file for Cantaloupe, or the current version of the source code, and then the build stage compiles Cantaloupe with Maven if the requested version = latest. The remainder of the build remains the same.