### PR TITLE
Add defensive measures against broken upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
 ARG CANTALOUPE_VERSION=4.0.3
+# LATEST_SAFE_COMMIT should be 'latest' or a commit hash; it is a defense against a broken upstream
+ARG LATEST_SAFE_COMMIT=latest
 FROM maven:3.6.0-jdk-11 AS MAVEN_TOOL_CHAIN
 ARG CANTALOUPE_VERSION
+ARG LATEST_SAFE_COMMIT
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
+ENV LATEST_SAFE_COMMIT=$LATEST_SAFE_COMMIT
 RUN mkdir -p /build && \
     cd /build && \
     if [ "$CANTALOUPE_VERSION" = 'latest' ] ; then \
-      curl -OL https://github.com/medusa-project/cantaloupe/archive/develop.zip; \
+      git clone https://github.com/medusa-project/cantaloupe.git && \
+      cd cantaloupe && \
+      if [ "$LATEST_SAFE_COMMIT" != 'latest' ] ; then \
+        git checkout -b "$LATEST_SAFE_COMMIT" "$LATEST_SAFE_COMMIT" ; \
+        sleep 1m ; \
+      fi && \
+      mvn -DskipTests=true clean package && \
+      mv target/cantaloupe-?.?-SNAPSHOT.zip "/build/Cantaloupe-${CANTALOUPE_VERSION}.zip" ; \
     else \
       curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; \
     fi
-
-# unzip and compile the Cantaloupe source code if $CANTALOUPE_VERSION = 'latest'
-WORKDIR /build/
-RUN if [ "$CANTALOUPE_VERSION" = 'latest' ]; then unzip develop.zip cantaloupe-develop/* && mv cantaloupe-develop src \
-    && cd src/ && cp test.properties.sample test.properties && mvn -Pfreedeps -DskipTests clean package \
-    && cp /build/src/target/cantaloupe-?.?-SNAPSHOT.zip /build/Cantaloupe-$CANTALOUPE_VERSION.zip; fi
 
 FROM openjdk:10-slim
 ARG CANTALOUPE_VERSION
@@ -25,9 +30,10 @@ EXPOSE 8182
 VOLUME /imageroot
 
 # Update packages and install tools
+#  Removing /var/lib/apt/lists/* prevents using `apt` unless you do `apt update` first
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends wget unzip graphicsmagick curl imagemagick libopenjp2-tools ffmpeg python && \
-    rm -rf /var/lib/apt/lists/* ### this command prevents future tinkering with apt
+    rm -rf /var/lib/apt/lists/*
 
 # Run non privileged
 RUN adduser --system cantaloupe
@@ -39,7 +45,7 @@ COPY --from=MAVEN_TOOL_CHAIN /build/Cantaloupe-$CANTALOUPE_VERSION.zip /tmp/Cant
 # Get and unpack Cantaloupe release archive
 RUN cd /usr/local \
  && unzip /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
- && ln -s cantaloupe-$CANTALOUPE_VERSION cantaloupe \
+ && ln -s cantaloupe-?.* cantaloupe \
  && rm -rf /tmp/Cantaloupe-$CANTALOUPE_VERSION \
  && rm /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
  && rm -rf /usr/local/cantaloupe-$CANTALOUPE_VERSION/deps
@@ -54,4 +60,4 @@ RUN mkdir -p /var/log/cantaloupe /var/cache/cantaloupe \
 
 USER cantaloupe
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe.properties -Xmx2g -jar /usr/local/cantaloupe/cantaloupe-$CANTALOUPE_VERSION.war"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe.properties -Xmx2g -jar /usr/local/cantaloupe/cantaloupe-*.war"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 ARG CANTALOUPE_VERSION=4.0.3
 # LATEST_SAFE_COMMIT should be 'latest' or a commit hash; it is a defense against a broken upstream
-ARG LATEST_SAFE_COMMIT=latest
+ARG COMMIT_REF=latest
 FROM maven:3.6.0-jdk-11 AS MAVEN_TOOL_CHAIN
 ARG CANTALOUPE_VERSION
-ARG LATEST_SAFE_COMMIT
+ARG COMMIT_REF
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
-ENV LATEST_SAFE_COMMIT=$LATEST_SAFE_COMMIT
+ENV COMMIT_REF=$COMMIT_REF
 RUN mkdir -p /build && \
     cd /build && \
     if [ "$CANTALOUPE_VERSION" = 'latest' ] ; then \
       git clone https://github.com/medusa-project/cantaloupe.git && \
       cd cantaloupe && \
-      if [ "$LATEST_SAFE_COMMIT" != 'latest' ] ; then \
-        git checkout -b "$LATEST_SAFE_COMMIT" "$LATEST_SAFE_COMMIT" ; \
+      if [ "$COMMIT_REF" != 'latest' ] ; then \
+        git checkout -b "$COMMIT_REF" "$COMMIT_REF" ; \
       fi && \
       mvn -DskipTests=true clean package && \
       mv target/cantaloupe-?.?-SNAPSHOT.zip "/build/Cantaloupe-${CANTALOUPE_VERSION}.zip" ; \
@@ -20,7 +20,7 @@ RUN mkdir -p /build && \
       curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; \
     fi
 
-FROM openjdk:10-slim
+FROM openjdk:11-slim
 ARG CANTALOUPE_VERSION
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN mkdir -p /build && \
       cd cantaloupe && \
       if [ "$LATEST_SAFE_COMMIT" != 'latest' ] ; then \
         git checkout -b "$LATEST_SAFE_COMMIT" "$LATEST_SAFE_COMMIT" ; \
-        sleep 1m ; \
       fi && \
       mvn -DskipTests=true clean package && \
       mv target/cantaloupe-?.?-SNAPSHOT.zip "/build/Cantaloupe-${CANTALOUPE_VERSION}.zip" ; \

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ To build the latest version of Cantaloupe from source, use the following:
 
     docker build --build-arg CANTALOUPE_VERSION=latest -t cantaloupe .
 
-If the upstream Cantaloupe project is broken, you can also build a last known good commit. To do this, supply a `LATEST_SAFE_COMMIT` argument:
+If the upstream Cantaloupe project is broken, you can also build a last known good commit (or a previous tag or working branch). To do this, supply a `COMMIT_REF` argument with a commit hash, tag, or branch name:
 
-    docker build --build-arg CANTALOUPE_VERSION="latest" --build-arg LATEST_SAFE_COMMIT="437a72d7" -t cantaloupe .
+    docker build --build-arg CANTALOUPE_VERSION="latest" --build-arg COMMIT_REF="437a72d7" -t cantaloupe .
 
 ### Run the container
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ To build the latest version of Cantaloupe from source, use the following:
 
     docker build --build-arg CANTALOUPE_VERSION=latest -t cantaloupe .
 
+If the upstream Cantaloupe project is broken, you can also build a last known good commit. To do this, supply a `LATEST_SAFE_COMMIT` argument:
+
+    docker build --build-arg CANTALOUPE_VERSION="latest" --build-arg LATEST_SAFE_COMMIT="437a72d7" -t cantaloupe .
+
 ### Run the container
 
  First you will need to set the environment variables required to run Cantaloupe. If you would like to test additional settings, ensure the cantaloupe.properties.tmpl template has the variable configured or you have set it as an environment variable.


### PR DESCRIPTION
We want to have the option to build against the latest developer snapshot. Sometimes this breaks though, so we need a way to defensively build the "last known good commit". This PR adds a `LATEST_SAFE_COMMIT` build argument. By default it's set for "latest" (which assumes a working Cantaloupe build), but it can be changed to a particular git commit hash to use that version of the code when building. This new argument is also documented in the README now.

The new argument only comes into play if someone is building CANTALOUPE_VERSION=latest. Otherwise, it's ignored.