### PR TITLE
Update Travis config to use push versioned artifacts to DockerHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,39 @@
 language: bash
 
+env:
+  global:
+  - COMMIT_REF="437a72d7"
+  matrix:
+  - "CANTALOUPE_VERSION=stable"
+  - "CANTALOUPE_VERSION=latest"
+
 services:
 - docker
+
+# Upgrade Docker to the current version and then login to DockerHub
+before_install:
+- .travis/upgrade.sh
 
 script:
 - tests/run-tests.sh
 
 after_success:
-- if [[ "$TRAVIS_BRANCH" == "master" ]]; then
-    echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin ;
-    docker tag cantaloupe $TAGGED_IMAGE ;
-    docker push $TAGGED_IMAGE ;
-  fi
+- .travis/deploy.sh
 
 notifications:
   email:
     recipients:
-    - ksclarke@ksclarke.io
+      - ksclarke@ksclarke.io
     on_success: change
     on_failure: change
 
-env:
-  global:
-  - secure: tc3WuBWPk+oEA6MxNKwxoZkGy8OZ22bmKrT/anhFh9bIlZ7Srk3HV9DKw+CnJ2v6Om90V6mnHOFVTWofHBNzke0Ew7q/vTusoIVj6eLJiREvqNJgqLA00/RvhMbvUmozOzxogEZG807g/5+NdJaLCRNfUxJuvfIBLpmITsQajnZaXjZnqlwtWGvguVEChPIlH2S2BVez/7dBbqYaQnjaKuJMMtDdMDf0wNhTqi+Cv3WcrMb5NxNelGXUR18mjDkGDOikB0JOpR+/UvKQRv9RejBOvA9pp39Anf5fx1pwjdcp4TsQYmsnOo/TNc7f2sKNQZOnZq6FDFwJ5lO0assidak4bEd1WouxdHmQ03M8vBJLUVSZh/JE2Pt/E/LBYNyeaBRqXN7K2oErPJBlbtCPnbCfJUpjJqpmOLHxlwZ28HSOBDNDGss4iW357T+VHrRylsvQocoHV/3rHNufB1fgDDjVEUZA2oLUOP6FRBdcW2LjBvtM/XTs8ow6HCfU77aonzvO/gso3gGOMnbjnrJHOMNRQ/chKBXWU1yIRcJW2dXvYqLKWzWDFj4lu7fTJy8MWRFOeoO0sk2Uq37PDR5982GsSw4N0kYhV7MwBy80HXBNaNU5/BfsQq9g8OreW2iY1d5FR59kXcqnJk7wJopNql0vbnOoXdd0S8Y/DuZ9eVs=
-  - secure: 98Uo4sm8YU1JThyRJr+HxYE7x7hBHUh+y8e/HRBEuo8v4ekT0+v3h2N8HWtloFDehYyc4tnLuujpe8/kiK24UMCl9CLoD6T9yj3DUwQSZPGhyfhvKZNWd+koscGflRDXzHW48GCuzy7BqXQp6yQpC3j/YwfNTc8FNxCqFpLr5lW8RFc//8M7kJj4AfZaiqIm6KjKDTTpcCDRVZ6ITxwbEgYyaYBqr6zcsh0bb1G72ui1X4kgnWmndhvlXjfVSZwC0JYcIspDPVRVyebhAt1IyyYVW88aI9PqPyvx+lH84384X2FkJWJs3Sm8yltAsG0XuDvRCgTwWcwrQLj4H5ms9GYOssys3QGEg1tOzJlilgNgujv3/h6mD6GC2osbx2asHzNHBN45m0yTJoeB8A1kq4220AtW6CLcqQ2D9NR8uwrGq9byvEFcs8oHcLEg+Co4nr9QwCfKIR9VTuUrCBQ0slkde/MAUIvK4J24ggZmtnZVosDEEMcMHZsi7t1Zhl6boMlYsWZ1F+vvEeVFxoMnJMPDQI6H/Bk4IGYzy1SgYqxPbSnF4+2XB9D6xhrjTutkhzyX7YK6KF7VSP0AZqxrwEW5UUPrLDg8GrMEPkLXqaOp0+/MdiHKNOLpkeOVwnWLIgB8Lwk+rRXxxHIXD6ZIibyNkjFhncr1lRkPkmm/ve0=
-  - secure: kGck0DHnXCj44nFq6XAyCzAehZW2HCKCpO8mu2YwVunqnMqLJkZUdNx5MciYd4ntw0abYpNmHKUmu4WgNcRfjH4WtVSbYRWBrDNh/TTp9njscaXb9gQjoHW/iqjze+zZKlo2KJZ5+j4Pw0i/wxjPgH6HClTM8r0CX0K6Mo+6jLyz4pZQjlRFaCJhsR+KbfMNZt+IUVGgiUoqn79tQVeVj1M4XA29zErX74Lfcj79/t1p5T2dk9zGC5floGhihc1Mc2Wy22eju01S8V+YizyHMW1fwUv0PaqjxCSIJpaAfBJvoBVn9k4xFF9dYjdnHVKXmfL+wZCbPMcMD6QNm+u8qpy4hszYfDko1ZkJq5m102VCXVuDiKaC8RykvSJvnGvr0j6lekZeJMH6GN7T5DfLaiXoaMBmfUTLNYzo2Rrx279/1JpV3yymeU9YVEioPjIj/R23iiQVavviNd7aYb4J8yhKXTy4ML/QdyAy6kaHdSX0sqKhDGYOtwx0x1l3gymMnRV7Snz/jE7UphwsYEdIIV2SGwBfHxT7p9EwHVWk40m3OvtxQ+wMT8/E5Qd20zfszi5V6cLmzpImCnZEW/XzJW/t+iPy//oSGf74Xt+dwwl89qeMDqTh9tgUUKH5GBspvPJQUkCORCYO+VTxpngdMFlaWqbhT03y/LeXwmZku1Q=
+#
+# Things one needs to set in their project's online Travis configuration
+#
+# DOCKER_PASSWORD - For logging into the Docker registery (e.g., DockerHub)
+# DOCKER_USERNAME - For logging into the Docker registery (e.g., DockerHub)
+# AUTH_TOKEN - For querying GitHub releases (otherwise, it's rate limited)
+# REG_OWNER - The DockerHub user or organization that owns the project 
+# REG_PROJECT - The DockerHub project to which the tagged image is being pushed
+# MASTER_BRANCH - The Git branch fromw which you want to push to the registry
+#

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,0 +1,46 @@
+#! /bin/bash
+
+#
+# A simple little Bash script to deploy our Docker image to DockerHub.
+#
+
+# To check for existing tags easily, we'll enable experimental features
+mkdir ~/.docker
+echo '{"experimental": "enabled"}' > ~/.docker/config.json
+
+# First, login to the Docker registry
+echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
+
+# What tag are we building, latest stable or the latest dev branch?
+if [[ "$TRAVIS_BRANCH" == "$MASTER_BRANCH" && "$CANTALOUPE_VERSION" != "latest" ]]; then
+  TAG=$(curl -S -H "Authorization: token $AUTH_TOKEN" \
+    "https://api.github.com/repos/medusa-project/cantaloupe/releases/latest" \
+    | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c2-)
+elif [[ "$TRAVIS_BRANCH" == "$MASTER_BRANCH" ]]; then
+  TAG="latest"
+fi
+
+# Make sure we found the latest stable if that's what we are building
+if [[ -z "$TAG" ]]; then
+  exit 1
+else
+  # Does this tag already exist in our Docker image registry?
+  TAG_EXISTS=$(docker manifest inspect "$REG_OWNER"/"$REG_PROJECT":"$TAG" > /dev/null 2>&1 ; \
+    echo $?)
+
+  # Right now, we're not deploying a tag that already exists in the registry
+  if [[ "$TAG_EXISTS" == "0" && "$TAG" != "latest" \
+      && "$TRAVIS_BRANCH" == "$MASTER_BRANCH" && "$HARD_REGISTRY_PUSH" != "true" ]]; then
+    echo "Release tag already exists; we don't need to push again"
+  elif [[ "$TRAVIS_BRANCH" == "$MASTER_BRANCH" || "$HARD_REGISTRY_PUSH" == "true" ]]; then
+    echo "Travis branch: $TRAVIS_BRANCH"
+    echo "Hard push: $HARD_REGISTRY_PUSH"
+    echo "Tag exists: $TAG_EXISTS"
+    echo "Tag: $TAG"
+
+    # If our build is a new stable version or a SNAPSHOT, we want to push to the registry
+    docker tag cantaloupe "${REG_OWNER}/${REG_PROJECT}:${TAG}"
+    docker push "${REG_OWNER}/${REG_PROJECT}:${TAG}"
+  fi
+fi
+

--- a/.travis/upgrade.sh
+++ b/.travis/upgrade.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Performs any provisioning needed for a clean build.
+#
+# This script is meant to be used either directly as a `before_install` step such that the next step
+# in the Travis build have the environment properly setup.
+
+set -o errexit
+
+upgrade() {
+  setup_dependencies
+
+  echo "INFO:
+  Done! Finished setting up Travis-CI machine.
+  "
+}
+
+# Takes care of updating any dependencies that the machine needs.
+setup_dependencies() {
+  echo "INFO:
+  Setting up dependencies.
+  "
+
+  sudo apt update -y
+  sudo apt install --only-upgrade docker-ce -y
+
+  docker info
+}
+
+upgrade

--- a/tests/run-locally.sh
+++ b/tests/run-locally.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# List of different types we want to run
+CANTALOUPE_VERSION="stable" COMMIT_REF="437a72d7" "$DIR/run-tests.sh"
+CANTALOUPE_VERSION="latest" COMMIT_REF="437a72d7" "$DIR/run-tests.sh"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,23 +5,11 @@ GREEN='\033[1;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-# An informational message in case a test fails
-die () {
-  echo ""
-  printf "${RED}Tests failed!${NC}\n"
-  echo ""
-  printf "  ${GREEN}To clean up the testing container, run:${NC}\n"
-  echo "    docker rm -f \"$(cat $1)\""
-  echo ""
-  printf "  ${GREEN}To clean up all system containers, run:${NC}\n"
-  echo "    docker rm -f \$(docker ps -a -q)"
-  echo ""
-
-  exit 1
-}
-
 # Our tests need Docker installed
 hash docker 2>/dev/null || { echo >&2 "I require Docker to be installed to run tests. Aborting."; exit 1; }
+
+# Tell what we're testing
+printf "${GREEN}Testing ${CANTALOUPE_VERSION} Cantaloupe build${NC}\n"
 
 # Place to store container ID so tests can use it
 CONTAINER_ID=$(mktemp)
@@ -29,22 +17,47 @@ CONTAINER_ID=$(mktemp)
 # Clean up any stale test artifacts
 docker rm -f melon
 
-# Build the project
-docker build -t cantaloupe .
+if [[ "$DIRTY" != "true" ]]; then
+  docker rmi -f cantaloupe
+fi
 
-# Run the project so it can be tested (will fail if docker-cantaloupe is already running)
-docker run -d -p 8182:8182 -e "ENDPOINT_ADMIN_SECRET=secret" -e "ENDPOINT_ADMIN_ENABLED=true" --name melon -v testimages:/imageroot cantaloupe > "${CONTAINER_ID}"
+# Build the project
+if [[ "$CANTALOUPE_VERSION" == "latest" ]]; then
+  # If we're using specific commit, tag, or branch, supply that value
+  if [[ ! -z "$COMMIT_REF" ]]; then
+    printf "${GREEN}Building specific reference point: ${COMMIT_REF}${NC}"
+    REF_BUILD_ARG="--build-arg COMMIT_REF=$COMMIT_REF"
+  else
+    printf "${GREEN}Building the latest development snapshot${NC}\n"
+    REF_BUILD_ARG=""
+  fi
+
+  docker build --build-arg CANTALOUPE_VERSION="latest" --build-arg COMMIT_REF="$COMMIT_REF" -t cantaloupe .
+else
+  printf "${GREEN}Building the latest stable release${NC}\n"
+  docker build -t cantaloupe .
+fi
+
+printf "${GREEN}Running the newly built container${NC}\n"
+
+# Run the project so it can be tested
+docker run -p 8182:8182 -d \
+  -e "ENDPOINT_ADMIN_SECRET=secret" -e "ENDPOINT_ADMIN_ENABLED=true" \
+  --name melon -v testimages:/imageroot cantaloupe > "$CONTAINER_ID"
+
+CONTAINER_ID=$(cat $CONTAINER_ID)
+printf "${GREEN}Container ID: $CONTAINER_ID${NC}\n"
 
 # Run the tests
-source tests/validate-results.sh "$CONTAINER_ID"
+source tests/validate-results.sh
 
 # Some hints about what to do with the test resources
 echo ""
 echo "For further in-container testing, run:"
-echo "  docker exec -it \"$(cat ${CONTAINER_ID})\" bash"
+echo "  docker exec -it \"${CONTAINER_ID}\" bash"
 echo ""
 echo "To clean up the testing container, run:"
-echo "  docker rm -f \"$(cat ${CONTAINER_ID})\""
+echo "  docker rm -f \"${CONTAINER_ID}\""
 echo ""
 echo "To clean up all system containers, run:"
 echo "  docker rm -f \$(docker ps -a -q)"

--- a/tests/validate-results.sh
+++ b/tests/validate-results.sh
@@ -13,17 +13,17 @@ die () {
 
   if [ "$TRAVIS" != 'true' ]; then
     printf "  ${GREEN}To clean up the testing container, run:${NC}\n"
-    echo "    docker rm -f \"$(cat $1)\""
+    echo "    docker rm -f \"$CONTAINER_ID\""
     echo ""
     printf "  ${GREEN}To clean up all system containers, run:${NC}\n"
     echo "    docker rm -f \$(docker ps -a -q)"
     echo ""
   fi
 
-  exit $2
+  exit $1
 }
 
 # These are the actual tests we run
-docker exec --tty "$(cat ${1})" env TERM=xterm ls /etc/cantaloupe.properties >> /dev/null 2>&1 || die "$1" "$?"
+docker exec --tty "$CONTAINER_ID" env TERM=xterm ls /etc/cantaloupe.properties || die "$?"
 
 printf "${GREEN}Tests ran successfully!${NC}\n"


### PR DESCRIPTION
We want to push a versioned artifact from each build (right now just stable releases and a dev snapshot) up into DockerHub. We do the build for each and then deploy it to DockerHub where we can later pull it down for use. The tests here are just placeholders for IIIF-23, but are needed to show that we're going through testing before we're pushing something into the registry.