### PR TITLE
Make build a little quieter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 env:
   global:
 # A particular commit ref can be used if Cantaloupe build is broken
-#  - COMMIT_REF="437a72d7"
+  - COMMIT_REF="5c897c92"
   matrix:
   - "CANTALOUPE_VERSION=stable"
   - "CANTALOUPE_VERSION=dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ RUN mkdir -p /build && \
       if [ "$COMMIT_REF" != 'latest' ] ; then \
         git checkout -b "$COMMIT_REF" "$COMMIT_REF" ; \
       fi && \
-      mvn -DskipTests=true clean package && \
+      mvn -DskipTests=true -q clean package && \
       mv target/cantaloupe-?.?-SNAPSHOT.zip "/build/Cantaloupe-${CANTALOUPE_VERSION}.zip" ; \
     else \
-      curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; \
+      curl -s -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; \
     fi
 
 FROM openjdk:11-slim


### PR DESCRIPTION
We're bumping into Travis' log limit (at which point they kill the job) so we need to reduce the unnecessary output in our build. This PR makes Maven and Curl a little quieter.