### PR TITLE
Iiif 59 fix openjpeg path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 env:
   global:
 # A particular commit ref can be used if Cantaloupe build is broken
-  - COMMIT_REF="5c897c92"
+#  - COMMIT_REF="5c897c92"
   matrix:
   - "CANTALOUPE_VERSION=stable"
   - "CANTALOUPE_VERSION=dev"

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -23,6 +23,10 @@ elif [[ "$TRAVIS_BRANCH" == "$MASTER_BRANCH" ]]; then
   TAG="latest"
 fi
 
+echo "Travis branch: $TRAVIS_BRANCH"
+echo "Hard push: $HARD_REGISTRY_PUSH"
+echo "Tag: $TAG"
+
 # Make sure we found the latest stable if that's what we are building
 if [[ -z "$TAG" ]]; then
   exit 1
@@ -36,10 +40,7 @@ else
       && "$TRAVIS_BRANCH" == "$MASTER_BRANCH" && "$HARD_REGISTRY_PUSH" != "true" ]]; then
     echo "Release tag already exists; we don't need to push again"
   elif [[ "$TRAVIS_BRANCH" == "$MASTER_BRANCH" || "$HARD_REGISTRY_PUSH" == "true" ]]; then
-    echo "Travis branch: $TRAVIS_BRANCH"
-    echo "Hard push: $HARD_REGISTRY_PUSH"
     echo "Tag exists: $TAG_EXISTS"
-    echo "Tag: $TAG"
 
     # If our build is a new stable version or a SNAPSHOT, we want to push to the registry
     docker tag "cantaloupe_${CANTALOUPE_VERSION}" "${REG_USERNAME}/${REG_PROJECT}:${TAG}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /build && \
       curl -s -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; \
     fi
 
-FROM openjdk:11-slim
+FROM ubuntu:18.04
 ARG CANTALOUPE_VERSION
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 
@@ -31,7 +31,8 @@ VOLUME /imageroot
 # Update packages and install tools
 #  Removing /var/lib/apt/lists/* prevents using `apt` unless you do `apt update` first
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends wget unzip graphicsmagick curl imagemagick libopenjp2-tools ffmpeg python && \
+    apt-get install -y --no-install-recommends wget unzip graphicsmagick curl imagemagick libopenjp2-tools \
+      ffmpeg python openjdk-11-jdk-headless && \
     rm -rf /var/lib/apt/lists/*
 
 # Run non privileged

--- a/cantaloupe.properties.default
+++ b/cantaloupe.properties.default
@@ -353,7 +353,7 @@ CANTALOUPE_KAKADUDEMOPROCESSOR_PATH_TO_BINARIES = /usr/local/bin
 
 ## Optional absolute path of the directory containing opj_decompress.
 # Overrides the PATH.
-CANTALOUPE_OPENJPEGPROCESSOR_PATH_TO_BINARIES = /usr/local/bin
+CANTALOUPE_OPENJPEGPROCESSOR_PATH_TO_BINARIES = /usr/bin
 
 ###########################################################################
 # CLIENT-SIDE CACHING

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -58,20 +58,12 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
         it { should be_grouped_into 'root' }
       end
 
-      # Check to see that OpenJPEG is installed
-      describe file('/usr/bin/opj_compress') do
-        it { should be_file }
-        it { should be_mode 755 }
-        it { should be_owned_by 'root'}
-        it { should be_grouped_into 'root' }
+      describe package('libopenjp2-tools') do
+        it { should be_installed.with_version('2.3.0-1') }
       end
 
-      # Check to see that Java is installed
-      describe file('/usr/lib/jvm/java-11-openjdk-amd64/bin/java') do
-        it { should be_file }
-        it { should be_mode 755 }
-        it { should be_owned_by 'root'}
-        it { should be_grouped_into 'root' }
+      describe package('openjdk-11-jre-headless') do
+        it { should be_installed }
       end
     end
   end

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -58,7 +58,16 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
         it { should be_grouped_into 'root' }
       end
 
+      # Check to see that OpenJPEG is installed
       describe file('/usr/bin/opj_compress') do
+        it { should be_file }
+        it { should be_mode 755 }
+        it { should be_owned_by 'root'}
+        it { should be_grouped_into 'root' }
+      end
+
+      # Check to see that Java is installed
+      describe file('/usr/lib/jvm/java-11-openjdk-amd64/bin/java') do
         it { should be_file }
         it { should be_mode 755 }
         it { should be_owned_by 'root'}

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -57,6 +57,13 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
         it { should be_owned_by 'cantaloupe'}
         it { should be_grouped_into 'root' }
       end
+
+      describe file('/usr/bin/opj_compress') do
+        it { should be_file }
+        it { should be_mode 755 }
+        it { should be_owned_by 'root'}
+        it { should be_grouped_into 'root' }
+      end
     end
   end
 end


### PR DESCRIPTION
* Fix the openjpeg tools path in the Cantaloupe default config
* Change to using Ubuntu base image to get the latest OpenJPEG library that we need to work with S3
* Remove COMMIT_REF now that Cantaloupe build is fixed
* Move deploy debugging around a little to get more information, earlier
* Add two more tests