### PR TITLE
Reduce unnecessary build output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV COMMIT_REF=$COMMIT_REF
 RUN mkdir -p /build && \
     cd /build && \
     if [ "$CANTALOUPE_VERSION" = 'dev' ] ; then \
-      git clone https://github.com/medusa-project/cantaloupe.git && \
+      git clone --quiet https://github.com/medusa-project/cantaloupe.git && \
       cd cantaloupe && \
       if [ "$COMMIT_REF" != 'latest' ] ; then \
         git checkout -b "$COMMIT_REF" "$COMMIT_REF" ; \
@@ -30,9 +30,10 @@ VOLUME /imageroot
 
 # Update packages and install tools
 #  Removing /var/lib/apt/lists/* prevents using `apt` unless you do `apt update` first
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends wget unzip graphicsmagick curl imagemagick libopenjp2-tools \
-      ffmpeg python openjdk-11-jdk-headless && \
+RUN apt-get update -qq -y && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -qq --no-install-recommends wget unzip graphicsmagick curl imagemagick \
+      libopenjp2-tools ffmpeg python openjdk-11-jdk-headless < /dev/null > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 
 # Run non privileged
@@ -44,7 +45,7 @@ COPY --from=MAVEN_TOOL_CHAIN /build/Cantaloupe-$CANTALOUPE_VERSION.zip /tmp/Cant
 
 # Get and unpack Cantaloupe release archive
 RUN cd /usr/local \
- && unzip /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
+ && unzip -qq /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
  && ln -s cantaloupe-?.* cantaloupe \
  && rm -rf /tmp/Cantaloupe-$CANTALOUPE_VERSION \
  && rm /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ VOLUME /imageroot
 
 # Update packages and install tools
 #  Removing /var/lib/apt/lists/* prevents using `apt` unless you do `apt update` first
-RUN apt-get update -qq -y && \
+RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -qq --no-install-recommends wget unzip graphicsmagick curl imagemagick \
       libopenjp2-tools ffmpeg python openjdk-11-jdk-headless < /dev/null > /dev/null && \

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,6 @@ task(:test) do
   RSpec::Core::Runner.run(['spec/cantaloupe_spec.rb'])
   RSpec.clear_examples
   ENV['CANTALOUPE_VERSION'] = 'dev'
-  #  ENV['COMMIT_REF'] = ''
   RSpec::Core::Runner.run(['spec/cantaloupe_spec.rb'])
 end
 

--- a/spec/Dockerfile.erb
+++ b/spec/Dockerfile.erb
@@ -2,8 +2,8 @@ FROM <%= reg_username %>cantaloupe_<%= cantaloupe_version %>
 
 USER root
 
-# iproute2 is required for integration tests so we install it and some additional tools
-RUN apt-get update && \
+# Install additional packages required for integration tests
+RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends --no-upgrade net-tools iproute2 procps && \
+    apt-get install -qq --no-install-recommends --no-upgrade net-tools iproute2 procps < /dev/null > /dev/null && \
     rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -21,7 +21,11 @@ elsif version == 'dev'
   # Build the _dev version of cantaloupe by calling docker here via a system call
   # this is required because we need to use --build-arg, and DockerSpec does not
   # currently support --build-ARG, see https://github.com/zuazo/dockerspec/issues/14
-  system('docker build --build-arg CANTALOUPE_VERSION=' + version + commit_ref + '-t ' + image_tag + ' .')
+  success = system('docker build --build-arg CANTALOUPE_VERSION=' + version + commit_ref + '-t ' + image_tag + ' .')
+
+  unless success
+    raise 'Failed to create dev docker-cantaloupe container for testing'
+  end
 else
   raise('No CANTALOUPE_VERSION set')
 end

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -15,13 +15,13 @@ if version == 'stable'
 
   describe docker_build('.', tag: image_tag)
 elsif version == 'dev'
-  commit_ref = ENV.key?('COMMIT_REF') ? '--build-arg COMMIT_REF=' + ENV['COMMIT_REF'] : ''
+  commit_ref = ENV.key?('COMMIT_REF') ? ' --build-arg COMMIT_REF=' + ENV['COMMIT_REF'] + ' ' : ' '
   expected_version = '4.1-SNAPSHOT'
 
   # Build the _dev version of cantaloupe by calling docker here via a system call
   # this is required because we need to use --build-arg, and DockerSpec does not
   # currently support --build-ARG, see https://github.com/zuazo/dockerspec/issues/14
-  system('docker build --build-arg \'CANTALOUPE_VERSION=\'' + version + '\' ' + commit_ref + ' -t ' + image_tag + ' .')
+  system('docker build --build-arg CANTALOUPE_VERSION=' + version + commit_ref + '-t ' + image_tag + ' .')
 else
   raise('No CANTALOUPE_VERSION set')
 end

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -22,10 +22,7 @@ elsif version == 'dev'
   # this is required because we need to use --build-arg, and DockerSpec does not
   # currently support --build-ARG, see https://github.com/zuazo/dockerspec/issues/14
   success = system('docker build --build-arg CANTALOUPE_VERSION=' + version + commit_ref + '-t ' + image_tag + ' .')
-
-  unless success
-    raise 'Failed to create dev docker-cantaloupe container for testing'
-  end
+  raise 'Failed to create dev docker-cantaloupe container for testing' unless success
 else
   raise('No CANTALOUPE_VERSION set')
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,20 @@ require 'erb'
 RSpec.configure do |config|
   config.log_level = :ci
   config.docker_wait = 60
+
+  original_stderr = $stderr
+  original_stdout = $stdout
+
+  config.before(:all) do
+    # Redirect stderr and stdout
+    $stderr = File.open(File::NULL, 'w')
+    $stdout = File.open(File::NULL, 'w')
+  end
+
+  config.after(:all) do
+    $stderr = original_stderr
+    $stdout = original_stdout
+  end
 end
 
 def save_dockerfile(file, content)
@@ -18,7 +32,7 @@ def create_test_dockerfile(reg_username)
   erb = ERB.new(template)
   dockerfile_content = erb.result(binding)
   tmp_dockerfile = Dir.mktmpdir + '/Dockerfile'
-  puts 'creating test dockerfile for cantaloupe version: ' + cantaloupe_version
+  puts 'creating test dockerfile for cantaloupe version: ' + cantaloupe_version + ' [' + tmp_dockerfile + ']'
   save_dockerfile(tmp_dockerfile, dockerfile_content)
   tmp_dockerfile
 end


### PR DESCRIPTION
Fixes [IIIF-55]

Also fixes a bug ([IIIF-70]) that went unnoticed previously because the build output was so voluminous (and Travis failed to fail the build when it happened).