### PR TITLE
[IIIF-57] Move commit_ref to UI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 
 env:
-  global:
-# A particular commit ref can be used if Cantaloupe build is broken
-#  - COMMIT_REF="5c897c92"
   matrix:
   - "CANTALOUPE_VERSION=stable"
   - "CANTALOUPE_VERSION=dev"
@@ -40,4 +37,5 @@ notifications:
 # REG_USERNAME - The DockerHub user or organization that owns the project
 # REG_PROJECT - The DockerHub project to which the tagged image is being pushed
 # MASTER_BRANCH - The Git branch fromw which you want to push to the registry
+# COMMIT_REF [Optional] - A tag, branch, or commit hash from which to build
 #


### PR DESCRIPTION
Move the location of the COMMIT_REF optional build argument to be in the Travis UI settings rather than in the .travis.yml file (which requires commits to change).