### PR TITLE
Only do Travis builds on master branch (and PRs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ script:
 after_success:
 - .travis/deploy.sh
 
+# We want all PRs built but only merges on master branch
+branches:
+  only:
+  - master
+
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Turn on builds on branches and PRs in the Travis config but only specify building on master branch in the Travis config _should_ give us builds on all PRs but only on 'master' branch?

https://stackoverflow.com/questions/31882306/how-to-configure-travis-ci-to-build-pull-requests-merges-to-master-w-o-redunda