### PR TITLE
[IIIF-88] set fail-if-no-example in spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'tmpdir'
 require 'erb'
 
 RSpec.configure do |config|
+  config.fail_if_no_examples = true
   config.log_level = :ci
   config.docker_wait = 60
 


### PR DESCRIPTION
- add fail-if-no-example to the spec_helper.rb config for rspec