### PR TITLE
[IIIF-89] Add fail-fast option to rspec.config in spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'erb'
 
 RSpec.configure do |config|
   config.fail_if_no_examples = true
+  config.fail_fast = 1
   config.log_level = :ci
   config.docker_wait = 60
 


### PR DESCRIPTION
- Add fail-fast option, so a single test failure fails the build immediately