### PR TITLE
[IIIF-76] Address concerns raised by Snyk by moving to Ubuntu 18.10 as a base image

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,13 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.3
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-RUBY-NOKOGIRI-20299:
+    - '*':
+        reason: dockerspec-is-for-testing
+        expires: 2020-04-01T00:00:00.000Z
+  SNYK-RUBY-ERUBIS-20482:
+    - '*':
+        reason: dockerspec-is-for-testing
+        expires: 2020-04-01T00:00:00.000Z
+patch: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,15 +31,15 @@ VOLUME /imageroot
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -qq --no-install-recommends \
-    libopenjp2-tools \
-    openjdk-11-jre-headless \
-    wget \
-    unzip \
-    graphicsmagick \
-    curl \
-    imagemagick \
-    ffmpeg \
-    python \
+    libopenjp2-tools=2.3.0-1 \
+    openjdk-11-jre-headless=11.0.1+13-3ubuntu3.18.10.1 \
+    wget=1.19.5-1ubuntu1 \
+    unzip=6.0-21ubuntu1 \
+    graphicsmagick=1.3.30+hg15796-1 \
+    curl=7.61.0-1ubuntu2.3 \
+    imagemagick=8:6.9.10.8+dfsg-1ubuntu2 \
+    ffmpeg=7:4.0.2-2 \
+    python=2.7.15-3 \
     < /dev/null > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN if [ "$CANTALOUPE_VERSION" = 'dev' ] ; then \
       curl -o ../Cantaloupe-$CANTALOUPE_VERSION.zip -s -L https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip; \
     fi
 
-FROM ubuntu:18.04
+FROM ubuntu:18.10
 ARG CANTALOUPE_VERSION
 ENV CANTALOUPE_VERSION=$CANTALOUPE_VERSION
 
@@ -31,15 +31,15 @@ VOLUME /imageroot
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -qq --no-install-recommends \
-    libopenjp2-tools=2.3.0-1 \
-    openjdk-11-jre-headless=10.0.2+13-1ubuntu0.18.04.4 \
-    wget=1.19.4-1ubuntu2.1 \
-    unzip=6.0-21ubuntu1 \
-    graphicsmagick=1.3.28-2 \
-    curl=7.58.0-2ubuntu3.6 \
-    imagemagick=8:6.9.7.4+dfsg-16ubuntu6.4 \
-    ffmpeg=7:3.4.4-0ubuntu0.18.04.1 \
-    python=2.7.15~rc1-1 \
+    libopenjp2-tools \
+    openjdk-11-jre-headless \
+    wget \
+    unzip \
+    graphicsmagick \
+    curl \
+    imagemagick \
+    ffmpeg \
+    python \
     < /dev/null > /dev/null && \
     rm -rf /var/lib/apt/lists/*
 

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -64,37 +64,37 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
         it { is_expected.to be_installed.with_version('2.3.0-1') }
       end
 
-      # describe package('openjdk-11-jre-headless') do
-      #   # it { is_expected.to be_installed.with_version('10.0.2+13-1ubuntu0.18.04.4') }
-      # end
+      describe package('openjdk-11-jre-headless') do
+        it { is_expected.to be_installed.with_version('11.0.1+13-3ubuntu3.18.10.1') }
+      end
 
-      # describe package('wget') do
-      #   it { is_expected.to be_installed.with_version('1.19.4-1ubuntu2.1') }
-      # end
+      describe package('wget') do
+        it { is_expected.to be_installed.with_version('1.19.5-1ubuntu1') }
+      end
 
       describe package('unzip') do
         it { is_expected.to be_installed.with_version('6.0-21ubuntu1') }
       end
 
-      # describe package('graphicsmagick') do
-      #   it { is_expected.to be_installed.with_version('1.3.28-2') }
-      # end
+      describe package('graphicsmagick') do
+        it { is_expected.to be_installed.with_version('1.3.30+hg15796-1') }
+      end
 
-      # describe package('curl') do
-      #   it { is_expected.to be_installed.with_version('7.58.0-2ubuntu3.6') }
-      # end
+      describe package('curl') do
+        it { is_expected.to be_installed.with_version('7.61.0-1ubuntu2.3') }
+      end
 
-      # describe package('imagemagick') do
-      #   it { is_expected.to be_installed.with_version('8:6.9.7.4+dfsg-16ubuntu6.4') }
-      # end
+      describe package('imagemagick') do
+        it { is_expected.to be_installed.with_version('8:6.9.10.8+dfsg-1ubuntu2') }
+      end
 
-      # describe package('ffmpeg') do
-      #   it { is_expected.to be_installed.with_version('7:3.4.4-0ubuntu0.18.04.1') }
-      # end
+      describe package('ffmpeg') do
+        it { is_expected.to be_installed.with_version('7:4.0.2-2') }
+      end
 
-      # describe package('python') do
-      #   it { is_expected.to be_installed.with_version('2.7.15~rc1-1') }
-      # end
+      describe package('python') do
+        it { is_expected.to be_installed.with_version('2.7.15-3') }
+      end
     end
   end
 end

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -64,37 +64,37 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
         it { is_expected.to be_installed.with_version('2.3.0-1') }
       end
 
-      describe package('openjdk-11-jre-headless') do
-        it { is_expected.to be_installed.with_version('10.0.2+13-1ubuntu0.18.04.4') }
-      end
+      # describe package('openjdk-11-jre-headless') do
+      #   # it { is_expected.to be_installed.with_version('10.0.2+13-1ubuntu0.18.04.4') }
+      # end
 
-      describe package('wget') do
-        it { is_expected.to be_installed.with_version('1.19.4-1ubuntu2.1') }
-      end
+      # describe package('wget') do
+      #   it { is_expected.to be_installed.with_version('1.19.4-1ubuntu2.1') }
+      # end
 
       describe package('unzip') do
         it { is_expected.to be_installed.with_version('6.0-21ubuntu1') }
       end
 
-      describe package('graphicsmagick') do
-        it { is_expected.to be_installed.with_version('1.3.28-2') }
-      end
+      # describe package('graphicsmagick') do
+      #   it { is_expected.to be_installed.with_version('1.3.28-2') }
+      # end
 
-      describe package('curl') do
-        it { is_expected.to be_installed.with_version('7.58.0-2ubuntu3.6') }
-      end
+      # describe package('curl') do
+      #   it { is_expected.to be_installed.with_version('7.58.0-2ubuntu3.6') }
+      # end
 
-      describe package('imagemagick') do
-        it { is_expected.to be_installed.with_version('8:6.9.7.4+dfsg-16ubuntu6.4') }
-      end
+      # describe package('imagemagick') do
+      #   it { is_expected.to be_installed.with_version('8:6.9.7.4+dfsg-16ubuntu6.4') }
+      # end
 
-      describe package('ffmpeg') do
-        it { is_expected.to be_installed.with_version('7:3.4.4-0ubuntu0.18.04.1') }
-      end
+      # describe package('ffmpeg') do
+      #   it { is_expected.to be_installed.with_version('7:3.4.4-0ubuntu0.18.04.1') }
+      # end
 
-      describe package('python') do
-        it { is_expected.to be_installed.with_version('2.7.15~rc1-1') }
-      end
+      # describe package('python') do
+      #   it { is_expected.to be_installed.with_version('2.7.15~rc1-1') }
+      # end
     end
   end
 end


### PR DESCRIPTION
- changes the base image for Ubuntu from 18.4 LTS to 18.10
- changes all pinned package versions to match what is provided by 18.10
- changes all tests to confirm new package version numbers
- adds a .snyk file to ignore two vulernable gem packages, from DockerSpec, because we do not deploy these gems, we just use DockerSpec for testing