### PR TITLE
Update README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Rudimentary containerization of the [Cantaloupe server](https://medusa-project.g
 
     docker build -t cantaloupe .
 
-This invocation will download the 4.0.3 (current at time of writing) release of the software. To override for
+This invocation will download the 4.1.1 (current at time of writing) release of the software. To override for
 newer (or older) versions:
 
     docker build --build-arg CANTALOUPE_VERSION=<desired version> -t cantaloupe .
 
-_Note:_ if you want to build a version other than 4.0.3 or 4.0.2 you will need to supply a Cantaloupe properties `template` and `defaults` file in the `configs` directory. These files should be named with the Cantaloupe version you are interested in building. If the version you need is close to one of the supplied version files, you can probably just copy that file and edit as appropriate.
+_Note:_ if you want to build a version other than 4.1.1, 4.1, 4.0.3, or 4.0.2 you will need to supply a Cantaloupe properties `template` and `defaults` file in the `configs` directory. These files should be named with the Cantaloupe version you are interested in building. If the version you need is close to one of the supplied version files, you can probably just copy that file and edit as appropriate.
 
 To build the latest development snapshot of Cantaloupe, use the following:
 


### PR DESCRIPTION
Oops, we missed updating the README doc to reflect the current version we build by default: 4.1.1.

Update README.md to reflect that.