### PR TITLE
[IIIF-188] optimize docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ WORKDIR /build/kakadu/"$KAKADU_VERSION"/make
 RUN if [ ! -z "$KAKADU_VERSION" ]; then \
       apt-get update -qq && \
       DEBIAN_FRONTEND=noninteractive apt-get install -qq --no-install-recommends \
-        openjdk-11-jdk-headless=11.0.2+9-3ubuntu1~18.10.3  \
+        openjdk-11-jdk-headless=11.0.3+7-1ubuntu2~18.10.1  \
         gcc=4:8.3.0-1ubuntu1.1 \
         make=4.2.1-1.2 \
         libtiff-tools=4.0.9-6ubuntu0.2 \
@@ -107,11 +107,11 @@ RUN apt-get update -qq && \
     libtiff5=4.0.9-6ubuntu0.2 \
     libtiff5-dev=4.0.9-6ubuntu0.2 \
     libopenjp2-tools=2.3.0-1 \
-    openjdk-11-jre-headless=11.0.2+9-3ubuntu1~18.10.3  \
+    openjdk-11-jre-headless=11.0.3+7-1ubuntu2~18.10.1  \
     wget=1.19.5-1ubuntu1.1 \
     unzip=6.0-21ubuntu1 \
     graphicsmagick=1.3.30+hg15796-1 \
-    curl=7.61.0-1ubuntu2.3 \
+    curl=7.61.0-1ubuntu2.4 \
     imagemagick=8:6.9.10.8+dfsg-1ubuntu2 \
     ffmpeg=7:4.0.4-0ubuntu1 \
     python=2.7.15-3 \

--- a/configs/cantaloupe.properties.default-4.1.2
+++ b/configs/cantaloupe.properties.default-4.1.2
@@ -1,0 +1,751 @@
+###########################################################################
+# Sample Cantaloupe configuration file
+#
+# Copy this file to `cantaloupe.properties` and edit as desired.
+#
+# Keys may change from version to version. See the "Upgrading" section of
+# the website.
+#
+# Most changes will take effect without restarting. Those that won't are
+# marked with "!!".
+###########################################################################
+
+# !! Leave blank to use the JVM default temporary directory.
+CANTALOUPE_TEMP_PATHNAME =
+
+# !! Configures the HTTP server. (Standalone mode only.)
+CANTALOUPE_HTTP_ENABLED = true
+CANTALOUPE_HTTP_HOST = 0.0.0.0
+CANTALOUPE_HTTP_PORT = 8182
+CANTALOUPE_HTTP_HTTP2_ENABLED = false
+
+# !! Configures the HTTPS server. (Standalone mode only.)
+CANTALOUPE_HTTPS_ENABLED = false
+CANTALOUPE_HTTPS_HOST = 0.0.0.0
+CANTALOUPE_HTTPS_PORT = 8183
+# Secure HTTP/2 requires Java 9 or later.
+CANTALOUPE_HTTPS_HTTP2_ENABLED = false
+
+# !! Available values are `JKS` and `PKCS12`. (Standalone mode only.)
+CANTALOUPE_HTTPS_KEY_STORE_TYPE = JKS
+CANTALOUPE_HTTPS_KEY_STORE_PASSWORD = myPassword
+CANTALOUPE_HTTPS_KEY_STORE_PATH = /path/to/keystore.jks
+CANTALOUPE_HTTPS_KEY_PASSWORD = myPassword
+
+# !! Maximum size of the HTTP(S) request queue. Leave blank to use the
+# default.
+CANTALOUPE_HTTP_ACCEPT_QUEUE_LIMIT =
+
+# Base URI to use for internal links, such as Link headers and JSON-LD
+# @id values, in a reverse-proxy context. This should only be used when
+# X-Forwarded-* headers cannot be used instead. (See the user manual.)
+CANTALOUPE_BASE_URI =
+
+# Normally, slashes in a URI path component must be percent-encoded as
+# "%2F". If your proxy is not able to pass these through without decoding,
+# you can define an alternate character or character sequence to substitute
+# for a slash. Supply the non-percent-encoded version here, and use the
+# percent-encoded version in URLs.
+CANTALOUPE_SLASH_SUBSTITUTE =
+
+# Maximum number of pixels to return in a response, to prevent overloading
+# the server. Requests for more pixels than this will receive an error
+# response. Set to 0 for no maximum.
+CANTALOUPE_MAX_PIXELS = 100000000
+
+# Maximum scale to allow (1.0 = full scale; 0 = no maximum).
+max_scale = 1.0
+
+CANTALOUPE_PRINT_STACK_TRACE_ON_ERROR_PAGE = true
+
+###########################################################################
+# DELEGATE SCRIPT
+###########################################################################
+
+# Enables the delegate script: a Ruby script containing various delegate
+# methods. (See the user manual.)
+CANTALOUPE_DELEGATE_SCRIPT_ENABLED = false
+
+# !! This can be an absolute path, or a filename; if only a filename is
+# specified, it will be searched for in the same folder as this file, and
+# then the current working directory.
+CANTALOUPE_DELEGATE_SCRIPT_PATHNAME = delegates.rb
+
+# Enables the invocation cache, which caches method invocations and return
+# values in memory. See the user manual for more information.
+CANTALOUPE_DELEGATE_SCRIPT_CACHE_ENABLED = false
+
+###########################################################################
+# ENDPOINTS
+###########################################################################
+
+# Enables the IIIF Image API 1.x endpoint, at /iiif/1.
+CANTALOUPE_ENDPOINT_IIIF_1_ENABLED = false
+
+# Enables the IIIF Image API 2.x endpoint, at /iiif/2.
+CANTALOUPE_ENDPOINT_IIIF_2_ENABLED = true
+
+# Controls the response Content-Disposition header for images. Allowed
+# values are `inline`, `attachment`, and `none`. This can be overridden
+# using the ?response-content-disposition query argument.
+CANTALOUPE_ENDPOINT_IIIF_CONTENT_DISPOSITION = inline
+
+# Minimum size that will be used in info.json `sizes` keys.
+CANTALOUPE_ENDPOINT_IIIF_MIN_SIZE = 64
+
+# Minimum size that will be used in info.json `tiles` keys. The user manual
+# explains how these are calculated.
+CANTALOUPE_ENDPOINT_IIIF_MIN_TILE_SIZE = 512
+
+# If true, requests for sizes other than those contained in an information
+# response will be denied.
+CANTALOUPE_ENDPOINT_IIIF_2_RESTRICT_TO_SIZES = false
+
+# Enables the Control Panel, at /admin.
+CANTALOUPE_ENDPOINT_ADMIN_ENABLED = false
+CANTALOUPE_ENDPOINT_ADMIN_USERNAME = admin
+CANTALOUPE_ENDPOINT_ADMIN_SECRET =
+
+# Enables the administrative HTTP API. (See the user manual.)
+CANTALOUPE_ENDPOINT_API_ENABLED = false
+
+# HTTP Basic credentials to access the HTTP API.
+CANTALOUPE_ENDPOINT_API_USERNAME =
+CANTALOUPE_ENDPOINT_API_SECRET =
+
+###########################################################################
+# SOURCES
+###########################################################################
+
+# Uses one source for all requests. Available values are `FilesystemSource`,
+# `HttpSource`, `JdbcSource`, `S3Source`, and `AzureStorageSource`.
+CANTALOUPE_SOURCE_STATIC = FilesystemSource
+
+# If true, `CANTALOUPE_SOURCE_STATIC` will be overridden, and the `source()` delegate
+# method will be used to select a source per-request.
+CANTALOUPE_SOURCE_DELEGATE = false
+
+#----------------------------------------
+# FilesystemSource
+#----------------------------------------
+
+# How to look up files. Allowed values are `BasicLookupStrategy` and
+# `ScriptLookupStrategy`. ScriptLookupStrategy uses the delegate script for
+# dynamic lookups; see the user manual.
+CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
+
+# Server-side path that will be prefixed to the identifier in the URL.
+# Trailing slash is important!
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /home/myself/images/
+
+# Server-side path or extension that will be suffixed to the identifier in
+# the URL.
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX =
+
+#----------------------------------------
+# HttpSource
+#----------------------------------------
+
+# Trusts insecure certificates and cipher suites.
+CANTALOUPE_HTTPSOURCE_ALLOW_INSECURE = false
+
+# Request timeout in seconds.
+CANTALOUPE_HTTPSOURCE_REQUEST_TIMEOUT =
+
+# Tells HttpSource how to look up resources. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses a delegate method for dynamic lookups; see the user manual.
+CANTALOUPE_HTTPSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
+
+# URL that will be prefixed to the identifier in the request URL.
+# Trailing slash is important!
+CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX = http://localhost/images/
+
+# Path, extension, query string, etc. that will be suffixed to the
+# identifier in the request URL.
+CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX =
+
+# Enables access to resources that require HTTP Basic authentication.
+CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_AUTH_BASIC_USERNAME =
+CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_AUTH_BASIC_SECRET =
+
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+CANTALOUPE_HTTPSOURCE_CHUNKING_ENABLED = true
+
+# Chunk size.
+CANTALOUPE_HTTPSOURCE_CHUNKING_CHUNK_SIZE = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+CANTALOUPE_HTTPSOURCE_CHUNKING_CACHE_ENABLED = true
+
+# Max per-request chunk cache size.
+CANTALOUPE_HTTPSOURCE_CHUNKING_CACHE_MAX_SIZE = 5M
+
+#----------------------------------------
+# S3Source
+#----------------------------------------
+
+# !! Endpoint URI.
+# For AWS endpoints, see:
+# https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+CANTALOUPE_S3SOURCE_ENDPOINT =
+
+# !! Credentials for your AWS account.
+# See: http://aws.amazon.com/security-credentials
+# Note that this info can be obtained from elsewhere rather than setting
+# it here; see the user manual.
+CANTALOUPE_S3SOURCE_ACCESS_KEY_ID =
+CANTALOUPE_S3SOURCE_SECRET_KEY =
+
+# How to look up objects. Allowed values are `BasicLookupStrategy` and
+# `ScriptLookupStrategy`. ScriptLookupStrategy uses a delegate method for
+# dynamic lookups; see the user manual.
+CANTALOUPE_S3SOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
+
+# !! Name of the bucket containing images to be served.
+CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME =
+
+# Path within the bucket that will be prefixed to the identifier in the URL.
+# Trailing slash is important!
+CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX =
+
+# Path or extension that will be suffixed to the identifier in the URL.
+CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX =
+
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+CANTALOUPE_S3SOURCE_CHUNKING_ENABLED = true
+
+# Chunk size.
+CANTALOUPE_S3SOURCE_CHUNKING_CHUNK_SIZE = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+CANTALOUPE_S3SOURCE_CHUNKING_CACHE_ENABLED = true
+
+# Max per-request chunk cache size.
+CANTALOUPE_S3SOURCE_CHUNKING_CACHE_MAX_SIZE = 5M
+
+#----------------------------------------
+# AzureStorageSource
+#----------------------------------------
+
+# !! Name of your Azure account.
+# Leave blank if using URI with a SAS token in your object key.
+CANTALOUPE_AZURESTORAGESOURCE_ACCOUNT_NAME =
+
+# !! Key of your Azure account.
+# Leave blank if using URI with a SAS token in your object key.
+CANTALOUPE_AZURESTORAGESOURCE_ACCOUNT_KEY =
+
+# !! Name of the container containing images to be served.
+# Leave blank if using URI with the container in your object key.
+CANTALOUPE_AZURESTORAGESOURCE_CONTAINER_NAME =
+
+# Tells AzureStorageSource how to look up objects. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses a delegate method for dynamic lookups; see the user manual.
+CANTALOUPE_AZURESTORAGESOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
+
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_ENABLED = true
+
+# Chunk size.
+CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_CHUNK_SIZE = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_CACHE_ENABLED = true
+
+# Max per-request chunk cache size.
+CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_CACHE_MAX_SIZE = 5M
+
+#----------------------------------------
+# JdbcSource
+#----------------------------------------
+
+# Note: JdbcSource requires some delegate methods to be implemented in
+# addition to the configuration here, and a JDBC driver to be installed on
+# the classpath; see the user manual.
+
+# !!
+CANTALOUPE_JDBCSOURCE_URL = jdbc:postgresql://localhost:5432/my_database
+# !!
+CANTALOUPE_JDBCSOURCE_USER = postgres
+# !!
+CANTALOUPE_JDBCSOURCE_PASSWORD = postgres
+
+# !! Connection timeout in seconds.
+CANTALOUPE_JDBCSOURCE_CONNECTION_TIMEOUT = 10
+
+###########################################################################
+# PROCESSORS
+###########################################################################
+
+#----------------------------------------
+# Processor Selection
+#----------------------------------------
+
+# * If set to `AutomaticSelectionStrategy`, a "best" available processor
+#   will be selected per-request based on formats and installed
+#   dependencies.
+# * If set to `ManualSelectionStrategy`, a processor will be chosen based
+#   on the rest of the keys in this section.
+CANTALOUPE_PROCESSOR_SELECTION_STRATEGY = AutomaticSelectionStrategy
+
+# Built-in processors are `Java2dProcessor`, `GraphicsMagickProcessor`,
+# `ImageMagickProcessor`, `TurboJpegProcessor`, `KakaduNativeProcessor`,
+# `KakaduDemoProcessor`, `OpenJpegProcessor`, `JaiProcessor`,
+# `PdfBoxProcessor`, and `FfmpegProcessor`.
+# Some of these have third-party dependencies and won't work out-of-the-box.
+
+# These format-specific definitions are optional.
+CANTALOUPE_MANUAL_PROCESSOR_AVI = FfmpegProcessor
+CANTALOUPE_MANUAL_PROCESSOR_BMP =
+CANTALOUPE_MANUAL_PROCESSOR_DCM = ImageMagickProcessor
+CANTALOUPE_MANUAL_PROCESSOR_FLV = FfmpegProcessor
+CANTALOUPE_MANUAL_PROCESSOR_GIF =
+CANTALOUPE_MANUAL_PROCESSOR_JP2 = KakaduNativeProcessor
+CANTALOUPE_MANUAL_PROCESSOR_JPG =
+CANTALOUPE_MANUAL_PROCESSOR_MOV = FfmpegProcessor
+CANTALOUPE_MANUAL_PROCESSOR_MP4 = FfmpegProcessor
+CANTALOUPE_MANUAL_PROCESSOR_MPG = FfmpegProcessor
+CANTALOUPE_MANUAL_PROCESSOR_PDF = PdfBoxProcessor
+CANTALOUPE_MANUAL_PROCESSOR_PNG =
+CANTALOUPE_MANUAL_PROCESSOR_TIF =
+CANTALOUPE_MANUAL_PROCESSOR_WEBM = FfmpegProcessor
+CANTALOUPE_MANUAL_PROCESSOR_WEBP = ImageMagickProcessor
+
+# Fall back to this processor for any formats not assigned above.
+CANTALOUPE_PROCESSOR_FALLBACK = Java2dProcessor
+
+#----------------------------------------
+# Global Processor Configuration
+#----------------------------------------
+
+# Controls how content is fed to processors from stream-based sources.
+# * `StreamStrategy` will try to stream a source image from a source when
+#   possible, and use `CANTALOUPE_PROCESSOR_FALLBACK_RETRIEVAL_STRATEGY` otherwise.
+# * `DownloadStrategy` will download it to a temporary file, and delete
+#   it after the request is complete.
+# * `CacheStrategy` will download it into the source cache using
+#   FilesystemCache, which must also be configured. (This will perform a
+#   lot better than DownloadStrategy if you can spare the disk space.)
+CANTALOUPE_PROCESSOR_STREAM_RETRIEVAL_STRATEGY = StreamStrategy
+
+# Controls how an incompatible StreamSource + FileProcessor combination is
+# dealt with.
+# * `DownloadStrategy` and `CacheStrategy` work the same as above.
+# * `AbortStrategy` causes the request to fail.
+CANTALOUPE_PROCESSOR_FALLBACK_RETRIEVAL_STRATEGY = DownloadStrategy
+
+# Resolution of vector rasterization (of e.g. PDFs) at a scale of 1.
+CANTALOUPE_PROCESSOR_DPI = 150
+
+# Color of the background when an image is rotated or alpha-flattened, for
+# output formats that don't support transparency.
+# This may not be respected for indexed color derivative images.
+CANTALOUPE_PROCESSOR_BACKGROUND_COLOR = white
+
+# Available values are `bell`, `bspline`, `bicubic`, `box`, `hermite`,
+# `lanczos3`, `mitchell`, `triangle`. (JaiProcessor & KakaduNativeProcessor
+# ignore these.)
+CANTALOUPE_PROCESSOR_DOWNSCALE_FILTER = bicubic
+CANTALOUPE_PROCESSOR_UPSCALE_FILTER = bicubic
+
+# Intensity of an unsharp mask from 0 to 1.
+CANTALOUPE_PROCESSOR_SHARPEN = 0
+
+# Attempts to copy source image metadata (EXIF, IPTC, XMP) into derivative
+# images. (This is not foolproof; see the user manual.)
+CANTALOUPE_PROCESSOR_METADATA_PRESERVE = false
+
+# Whether to auto-rotate images using the EXIF `Orientation` field.
+# The check for this field can impair performance slightly.
+CANTALOUPE_PROCESSOR_METADATA_RESPECT_ORIENTATION = false
+
+# Progressive JPEGs are usually more compact.
+CANTALOUPE_PROCESSOR_JPG_PROGRESSIVE = true
+
+# JPEG output quality (1-100).
+CANTALOUPE_PROCESSOR_JPG_QUALITY = 80
+
+# TIFF output compression type. Available values are `Deflate`, `JPEG`,
+# `LZW`, and `RLE`. Leave blank for no compression.
+CANTALOUPE_PROCESSOR_TIF_COMPRESSION = LZW
+
+#----------------------------------------
+# ImageIO Plugin Preferences
+#----------------------------------------
+
+# These override the default plugins used by the application and should not
+# normally be changed.
+CANTALOUPE_PROCESSOR_IMAGEIO_BMP_READER =
+CANTALOUPE_PROCESSOR_IMAGEIO_GIF_READER =
+CANTALOUPE_PROCESSOR_IMAGEIO_GIF_WRITER =
+CANTALOUPE_PROCESSOR_IMAGEIO_JPG_READER =
+CANTALOUPE_PROCESSOR_IMAGEIO_JPG_WRITER =
+CANTALOUPE_PROCESSOR_IMAGEIO_PNG_READER =
+CANTALOUPE_PROCESSOR_IMAGEIO_PNG_WRITER =
+CANTALOUPE_PROCESSOR_IMAGEIO_TIF_READER =
+CANTALOUPE_PROCESSOR_IMAGEIO_TIF_WRITER =
+
+#----------------------------------------
+# FfmpegProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing the FFmpeg binaries.
+# Overrides the PATH.
+CANTALOUPE_FFMPEGPROCESSOR_PATH_TO_BINARIES =
+
+#----------------------------------------
+# GraphicsMagickProcessor
+#----------------------------------------
+
+# !! Optional absolute path of the directory containing the GraphicsMagick
+# binary. Overrides the PATH.
+CANTALOUPE_GRAPHICSMAGICKPROCESSOR_PATH_TO_BINARIES =
+
+#----------------------------------------
+# ImageMagickProcessor
+#----------------------------------------
+
+# !! Optional absolute path of the directory containing the ImageMagick
+# binary. Overrides the PATH.
+CANTALOUPE_IMAGEMAGICKPROCESSOR_PATH_TO_BINARIES =
+
+#----------------------------------------
+# KakaduDemoProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing kdu_expand.
+# Overrides the PATH.
+CANTALOUPE_KAKADUDEMOPROCESSOR_PATH_TO_BINARIES =
+
+#----------------------------------------
+# OpenJpegProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing opj_decompress.
+# Overrides the PATH.
+CANTALOUPE_OPENJPEGPROCESSOR_PATH_TO_BINARIES =
+
+###########################################################################
+# CLIENT-SIDE CACHING
+###########################################################################
+
+# Whether to enable the response Cache-Control header.
+CANTALOUPE_CACHE_CLIENT_ENABLED = true
+
+CANTALOUPE_CACHE_CLIENT_MAX_AGE = 2592000
+CANTALOUPE_CACHE_CLIENT_SHARED_MAX_AGE =
+CANTALOUPE_CACHE_CLIENT_PUBLIC = true
+CANTALOUPE_CACHE_CLIENT_PRIVATE = false
+CANTALOUPE_CACHE_CLIENT_NO_CACHE = false
+CANTALOUPE_CACHE_CLIENT_NO_STORE = false
+CANTALOUPE_CACHE_CLIENT_MUST_REVALIDATE = false
+CANTALOUPE_CACHE_CLIENT_PROXY_REVALIDATE = false
+CANTALOUPE_CACHE_CLIENT_NO_TRANSFORM = true
+
+###########################################################################
+# SERVER-SIDE CACHING
+###########################################################################
+
+# N.B.: The source cache may be used if the
+# `CANTALOUPE_PROCESSOR_STREAM_RETRIEVAL_STRATEGY` and/or
+# `CANTALOUPE_PROCESSOR_FALLBACK_RETRIEVAL_STRATEGY` keys are set to `CacheStrategy`.
+
+# FilesystemCache is the only available source cache.
+CANTALOUPE_CACHE_SERVER_SOURCE = FilesystemCache
+
+# Amount of time source cache content remains valid. Set to blank or 0
+# for forever.
+CANTALOUPE_CACHE_SERVER_SOURCE.ttl_seconds = 2592000
+
+# Enables the derivative (processed image) cache.
+CANTALOUPE_CACHE_SERVER_DERIVATIVE_ENABLED = false
+
+# Available values are `FilesystemCache`, `JdbcCache`, `RedisCache`,
+# `HeapCache`, `S3Cache`, and `AzureStorageCache`.
+CANTALOUPE_CACHE_SERVER_DERIVATIVE =
+
+# Amount of time derivative cache content remains valid. Set to blank or 0
+# for forever.
+CANTALOUPE_CACHE_SERVER_DERIVATIVE.ttl_seconds = 2592000
+
+# Whether to use the Java heap as a "level 1" cache for image infos, either
+# independently or in front of a "level 2" derivative cache (if enabled).
+CANTALOUPE_CACHE_SERVER_INFO_ENABLED = true
+
+# If true, when a source reports that the requested source image has gone
+# missing, all cached information relating to it (if any) will be deleted.
+# (This is effectively always false when CANTALOUPE_CACHE_SERVER_RESOLVE_FIRST is also
+# false.)
+CANTALOUPE_CACHE_SERVER_PURGE_MISSING = false
+
+# If true, the source image will be confirmed to exist before a cached copy
+# is returned. If false, the cached copy will be returned without checking.
+# Resolving first is safer but slower.
+CANTALOUPE_CACHE_SERVER_RESOLVE_FIRST = false
+
+# !! Enables the cache worker, which periodically purges invalid cache
+# items in the background.
+CANTALOUPE_CACHE_SERVER_WORKER_ENABLED = false
+
+# !! The cache worker will wait this many seconds before starting its
+# next shift.
+CANTALOUPE_CACHE_SERVER_WORKER_INTERVAL = 86400
+
+#----------------------------------------
+# FilesystemCache
+#----------------------------------------
+
+# If this directory does not exist, it will be created automatically.
+CANTALOUPE_FILESYSTEMCACHE_PATHNAME = /var/cache/cantaloupe
+
+# Levels of folder hierarchy in which to store cached images. Deeper depth
+# results in fewer files per directory. Set to 0 to disable subdirectories.
+# Purge the cache after changing this.
+CANTALOUPE_FILESYSTEMCACHE_DIR_DEPTH = 3
+
+# Number of characters in tree directory names. Should be set to
+# 16^n < (max number of directory entries your filesystem can deal with).
+# Purge the cache after changing this.
+CANTALOUPE_FILESYSTEMCACHE_DIR_NAME_LENGTH = 2
+
+#----------------------------------------
+# HeapCache
+#----------------------------------------
+
+# Target cache size, in bytes or a number ending in M, MB, G, GB, etc.
+# This is not a hard limit, and may be transiently exceeded.
+# Ensure your heap can accommodate this size.
+CANTALOUPE_HEAPCACHE_TARGET_SIZE = 2G
+
+# If true, the cache contents will be written to a file on exit and during
+# cache worker shifts, and read back in at startup.
+CANTALOUPE_HEAPCACHE_PERSIST = false
+
+# When the contents are persisted, this specifies the location of the cache
+# file. If the parent directory does not exist, it will be created
+# automatically.
+CANTALOUPE_HEAPCACHE_PERSIST.filesystem.pathname = /var/cache/cantaloupe/heap.cache
+
+#----------------------------------------
+# JdbcCache
+#----------------------------------------
+
+# !!
+CANTALOUPE_JDBCCACHE_URL = jdbc:postgresql://localhost:5432/cantaloupe
+# !!
+CANTALOUPE_JDBCCACHE_USER = postgres
+# !!
+CANTALOUPE_JDBCCACHE_PASSWORD =
+
+# !! Connection timeout in seconds.
+CANTALOUPE_JDBCCACHE_CONNECTION_TIMEOUT = 10
+
+# These must be created manually; see the user manual.
+CANTALOUPE_JDBCCACHE_DERIVATIVE_IMAGE_TABLE = derivative_cache
+CANTALOUPE_JDBCCACHE_INFO_TABLE = info_cache
+
+#----------------------------------------
+# S3Cache
+#----------------------------------------
+
+# !! Endpoint URI.
+# For AWS endpoints, see:
+# https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+CANTALOUPE_S3CACHE_ENDPOINT =
+
+# !! Credentials for your AWS account.
+# See: http://aws.amazon.com/security-credentials
+# Note that this info can be obtained from elsewhere rather than setting it
+# here; see the user manual.
+CANTALOUPE_S3CACHE_ACCESS_KEY_ID =
+CANTALOUPE_S3CACHE_SECRET_KEY =
+
+# !! Name of a bucket to use to hold cached data.
+CANTALOUPE_S3CACHE_BUCKET_NAME =
+
+# !! String that will be prefixed to object keys.
+CANTALOUPE_S3CACHE_OBJECT_KEY_PREFIX =
+
+# !! Maximum number of concurrent HTTP connections to AWS. Leave blank to
+# use the default.
+CANTALOUPE_S3CACHE_MAX_CONNECTIONS =
+
+#----------------------------------------
+# AzureStorageCache
+#----------------------------------------
+
+# !! Credentials for your Azure account.
+CANTALOUPE_AZURESTORAGECACHE_ACCOUNT_NAME =
+CANTALOUPE_AZURESTORAGECACHE_ACCOUNT_KEY =
+
+# !! Name of the container containing cached images.
+CANTALOUPE_AZURESTORAGECACHE_CONTAINER_NAME =
+
+# !! String that will be prefixed to object keys.
+CANTALOUPE_AZURESTORAGECACHE_OBJECT_KEY_PREFIX =
+
+#----------------------------------------
+# RedisCache
+#----------------------------------------
+
+# !! Redis connection info.
+CANTALOUPE_REDISCACHE_HOST = localhost
+CANTALOUPE_REDISCACHE_PORT = 6379
+CANTALOUPE_REDISCACHE_SSL = false
+CANTALOUPE_REDISCACHE_PASSWORD =
+CANTALOUPE_REDISCACHE_DATABASE = 0
+
+###########################################################################
+# OVERLAYS
+###########################################################################
+
+# Whether to enable overlays.
+CANTALOUPE_OVERLAYS_ENABLED = false
+
+# Controls how overlays are configured. `BasicStrategy` will use the
+# `overlays.BasicStrategy.*` keys in this section. `ScriptStrategy` will
+# use a delegate method. (See the user manual.)
+CANTALOUPE_OVERLAYS_STRATEGY = BasicStrategy
+
+# `image` or `string`.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_TYPE = image
+
+# Absolute path or URL of the overlay image. Must be a PNG file.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_IMAGE = /path/to/overlay.png
+
+# Overlay text.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING = Copyright © My Great Organization\nAll rights reserved.
+
+# For possible values, launch with the -Dcantaloupe.list_fonts option.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.font = Helvetica
+
+# Font size in points.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.font.size = 24
+
+# If the string doesn't fit in the image at the above size, the largest size
+# at which it does fit will be used, down to this.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.font.min_size = 18
+
+# Font weight. 1 = regular, 2 = bold. Unfortunately, many fonts don't
+# support fractional weights.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.font.weight = 1.0
+
+# Point spacing between glyphs, typically between -0.1 and 0.1.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.glyph_spacing = 0.02
+
+# CSS color syntax is supported.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.color = white
+
+# CSS color syntax is supported.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.stroke.color = black
+
+# Stroke width in pixels.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.stroke.width = 1
+
+# Color of a rectangular background to draw under the string.
+# CSS color syntax and alpha are supported.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING.background.color = rgba(0, 0, 0, 100)
+
+# Allowed values: `top left`, `top center`, `top right`, `left center`,
+# `center`, `right center`, `bottom left`, `bottom center`, `bottom right`,
+# `repeat` (images only).
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_POSITION = bottom right
+
+# Pixel margin between the overlay and the image edge. Does not apply to
+# `repeat` position.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_INSET = 10
+
+# Output images less than this many pixels wide will not receive an overlay.
+# Set to 0 to add the overlay regardless.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_OUTPUT_WIDTH_THRESHOLD = 400
+
+# Output images less than this many pixels tall will not receive an overlay.
+# Set to 0 to add the overlay regardless.
+CANTALOUPE_OVERLAYS_BASICSTRATEGY_OUTPUT_HEIGHT_THRESHOLD = 300
+
+###########################################################################
+# REDACTIONS
+###########################################################################
+
+# See the user manual for information about how redactions work.
+CANTALOUPE_REDACTION_ENABLED = false
+
+###########################################################################
+# LOGGING
+###########################################################################
+
+#----------------------------------------
+# Application Log
+#----------------------------------------
+
+# `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
+CANTALOUPE_LOG_APPLICATION_LEVEL = debug
+
+CANTALOUPE_LOG_APPLICATION_CONSOLEAPPENDER_ENABLED = true
+
+# N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
+CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_ENABLED = false
+CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_PATHNAME = /path/to/logs/application.log
+
+CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_ENABLED = false
+CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_PATHNAME = /path/to/logs/application.log
+CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_POLICY = TimeBasedRollingPolicy
+CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_FILENAME_PATTERN = /path/to/logs/application-%d{yyyy-MM-dd}.log
+CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_MAX_HISTORY = 30
+
+# See the "SyslogAppender" section for a list of facilities:
+# http://logback.qos.ch/manual/appenders.html
+CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_ENABLED = false
+CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_HOST =
+CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_PORT = 514
+CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_FACILITY = LOCAL0
+
+#----------------------------------------
+# Error Log
+#----------------------------------------
+
+# Application log messages with a severity of WARN or greater can be copied
+# into a dedicated error log, which may make them easier to spot.
+
+# N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
+CANTALOUPE_LOG_ERROR_FILEAPPENDER_ENABLED = false
+CANTALOUPE_LOG_ERROR_FILEAPPENDER_PATHNAME = /path/to/logs/error.log
+
+CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_ENABLED = false
+CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_PATHNAME = /path/to/logs/error.log
+CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_POLICY = TimeBasedRollingPolicy
+CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_FILENAME_PATTERN = /path/to/logs/error-%d{yyyy-MM-dd}.log
+CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_MAX_HISTORY = 30
+
+#----------------------------------------
+# Access Log
+#----------------------------------------
+
+CANTALOUPE_LOG_ACCESS_CONSOLEAPPENDER_ENABLED = false
+
+# N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
+CANTALOUPE_LOG_ACCESS_FILEAPPENDER_ENABLED = false
+CANTALOUPE_LOG_ACCESS_FILEAPPENDER_PATHNAME = /path/to/logs/access.log
+
+# RollingFileAppender is an alternative to using something like
+# FileAppender + logrotate.
+CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_ENABLED = false
+CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_PATHNAME = /path/to/logs/access.log
+CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_POLICY = TimeBasedRollingPolicy
+CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_FILENAME_PATTERN = /path/to/logs/access-%d{yyyy-MM-dd}.log
+CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_MAX_HISTORY = 30
+
+# See the "SyslogAppender" section for a list of facilities:
+# http://logback.qos.ch/manual/appenders.html
+CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_ENABLED = false
+CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_HOST =
+CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_PORT = 514
+CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_FACILITY = LOCAL0

--- a/configs/cantaloupe.properties.tmpl-4.1.2
+++ b/configs/cantaloupe.properties.tmpl-4.1.2
@@ -1,0 +1,390 @@
+###########################################################################
+# Template configuration file for Cantaloupe
+#
+# Most changes will take effect without restarting. Those that won't are
+# marked with "!!".
+###########################################################################
+
+###########################################################################
+# GENERAL SETTINGS
+###########################################################################
+
+temp_pathname = $CANTALOUPE_TEMP_PATHNAME
+http.enabled = $CANTALOUPE_HTTP_ENABLED
+http.host = $CANTALOUPE_HTTP_HOST
+http.port = $CANTALOUPE_HTTP_PORT
+http.http2.enabled = $CANTALOUPE_HTTP_HTTP2_ENABLED
+https.enabled = $CANTALOUPE_HTTPS_ENABLED
+https.host = $CANTALOUPE_HTTPS_HOST
+https.port = $CANTALOUPE_HTTPS_PORT
+https.http2.enabled = $CANTALOUPE_HTTPS_HTTP2_ENABLED
+https.key_store_type = $CANTALOUPE_HTTPS_KEY_STORE_TYPE
+https.key_store_password = $CANTALOUPE_HTTPS_KEY_STORE_PASSWORD
+https.key_store_path = $CANTALOUPE_HTTPS_KEY_STORE_PATH
+https.key_password = $CANTALOUPE_HTTPS_KEY_PASSWORD
+http.accept_queue_limit = $CANTALOUPE_HTTP_ACCEPT_QUEUE_LIMIT
+base_uri = $CANTALOUPE_BASE_URI
+slash_substitute = $CANTALOUPE_SLASH_SUBSTITUTE
+max_pixels = $CANTALOUPE_MAX_PIXELS
+print_stack_trace_on_error_pages = $CANTALOUPE_PRINT_STACK_TRACE_ON_ERROR_PAGE
+
+
+###########################################################################
+# DELEGATE SCRIPT
+###########################################################################
+
+delegate_script.enabled = $CANTALOUPE_DELEGATE_SCRIPT_ENABLED
+delegate_script.pathname = $CANTALOUPE_DELEGATE_SCRIPT_PATHNAME
+delegate_script.cache.enabled = $CANTALOUPE_DELEGATE_SCRIPT_CACHE_ENABLED
+
+###########################################################################
+# ENDPOINTS
+###########################################################################
+
+endpoint.public.auth.basic.enabled = $CANTALOUPE_ENDPOINT_PUBLIC_AUTH_BASIC_ENABLED
+endpoint.public.auth.basic.username = $CANTALOUPE_ENDPOINT_PUBLIC_AUTH_BASIC_USERNAME
+endpoint.public.auth.basic.secret = $CANTALOUPE_ENDPOINT_PUBLIC_AUTH_BASIC_SECRET
+endpoint.iiif.1.enabled = $CANTALOUPE_ENDPOINT_IIIF_1_ENABLED
+endpoint.iiif.2.enabled = $CANTALOUPE_ENDPOINT_IIIF_2_ENABLED
+endpoint.iiif.content_disposition = $CANTALOUPE_ENDPOINT_IIIF_CONTENT_DISPOSITION
+endpoint.iiif.min_size = $CANTALOUPE_ENDPOINT_IIIF_MIN_SIZE
+endpoint.iiif.min_tile_size = $CANTALOUPE_ENDPOINT_IIIF_MIN_TILE_SIZE
+endpoint.iiif.2.restrict_to_sizes = $CANTALOUPE_ENDPOINT_IIIF_2_RESTRICT_TO_SIZES
+endpoint.admin.enabled = $CANTALOUPE_ENDPOINT_ADMIN_ENABLED
+endpoint.admin.username = $CANTALOUPE_ENDPOINT_ADMIN_USERNAME
+endpoint.admin.secret = $CANTALOUPE_ENDPOINT_ADMIN_SECRET
+endpoint.api.enabled = $CANTALOUPE_ENDPOINT_API_ENABLED
+endpoint.api.username = $CANTALOUPE_ENDPOINT_API_USERNAME
+endpoint.api.secret = $CANTALOUPE_ENDPOINT_API_SECRET
+
+###########################################################################
+# SOURCES
+###########################################################################
+
+source.static = $CANTALOUPE_SOURCE_STATIC
+source.delegate = $CANTALOUPE_SOURCE_DELEGATE
+
+#----------------------------------------
+# FilesystemSource
+#----------------------------------------
+
+FilesystemSource.lookup_strategy = $CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY
+FilesystemSource.BasicLookupStrategy.path_prefix = $CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX
+FilesystemSource.BasicLookupStrategy.path_suffix = $CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX
+
+#----------------------------------------
+# HttpSource
+#----------------------------------------
+
+HttpSource.allow_insecure = $CANTALOUPE_HTTPSOURCE_ALLOW_INSECURE
+HttpSource.request_timeout = $CANTALOUPE_HTTPSOURCE_REQUEST_TIMEOUT
+HttpSource.lookup_strategy = $CANTALOUPE_HTTPSOURCE_LOOKUP_STRATEGY
+HttpSource.BasicLookupStrategy.url_prefix = $CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_PREFIX
+HttpSource.BasicLookupStrategy.url_suffix = $CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_URL_SUFFIX
+HttpSource.BasicLookupStrategy.auth.basic.username = $CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_AUTH_BASIC_USERNAME
+HttpSource.BasicLookupStrategy.auth.basic.secret = $CANTALOUPE_HTTPSOURCE_BASICLOOKUPSTRATEGY_AUTH_BASIC_SECRET
+HttpSource.chunking.enabled = $CANTALOUPE_HTTPSOURCE_CHUNKING_ENABLED
+HttpSource.chunking.chunk_size = $CANTALOUPE_HTTPSOURCE_CHUNKING_CHUNK_SIZE
+HttpSource.chunking.cache.enabled = $CANTALOUPE_HTTPSOURCE_CHUNKING_CACHE_ENABLED
+HttpSource.chunking.cache.max_size = $CANTALOUPE_HTTPSOURCE_CHUNKING_CACHE_MAX_SIZE
+
+#----------------------------------------
+# S3Source
+#----------------------------------------
+
+S3Source.endpoint = $CANTALOUPE_S3SOURCE_ENDPOINT
+S3Source.access_key_id = $CANTALOUPE_S3SOURCE_ACCESS_KEY_ID
+S3Source.secret_key = $CANTALOUPE_S3SOURCE_SECRET_KEY
+S3Source.max_connections = $CANTALOUPE_S3SOURCE_MAX_CONNECTIONS
+S3Source.lookup_strategy = $CANTALOUPE_S3SOURCE_LOOKUP_STRATEGY
+S3Source.BasicLookupStrategy.bucket.name = $CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME
+S3Source.BasicLookupStrategy.path_prefix = $CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX
+S3Source.BasicLookupStrategy.path_suffix = $CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX
+S3Source.chunking.enabled = $CANTALOUPE_S3SOURCE_CHUNKING_ENABLED
+S3Source.chunking.chunk_size = $CANTALOUPE_S3SOURCE_CHUNKING_CHUNK_SIZE
+S3Source.chunking.cache.enabled = $CANTALOUPE_S3SOURCE_CHUNKING_CACHE_ENABLED
+S3Source.chunking.cache.max_size = $CANTALOUPE_S3SOURCE_CHUNKING_CACHE_MAX_SIZE
+
+#----------------------------------------
+# AzureStorageSource
+#----------------------------------------
+
+AzureStorageSource.account_name = $CANTALOUPE_AZURESTORAGESOURCE_ACCOUNT_NAME
+AzureStorageSource.account_key = $CANTALOUPE_AZURESTORAGESOURCE_ACCOUNT_KEY
+AzureStorageSource.container_name = $CANTALOUPE_AZURESTORAGESOURCE_CONTAINER_NAME
+AzureStorageSource.lookup_strategy = $CANTALOUPE_AZURESTORAGESOURCE_LOOKUP_STRATEGY
+AzureStorageSource.chunking.enabled = $CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_ENABLED
+AzureStorageSource.chunking.chunk_size = $CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_CHUNK_SIZE
+AzureStorageSource.chunking.cache.enabled = $CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_CACHE_ENABLED
+AzureStorageSource.chunking.cache.max_size = $CANTALOUPE_AZURESTORAGESOURCE_CHUNKING_CACHE_MAX_SIZE
+
+#----------------------------------------
+# JdbcSource
+#----------------------------------------
+
+JdbcSource.url = $CANTALOUPE_JDBCSOURCE_URL
+JdbcSource.user = $CANTALOUPE_JDBCSOURCE_USER
+JdbcSource.password = $CANTALOUPE_JDBCSOURCE_PASSWORD
+JdbcSource.connection_timeout = $CANTALOUPE_JDBCSOURCE_CONNECTION_TIMEOUT
+
+###########################################################################
+# PROCESSORS
+###########################################################################
+
+#----------------------------------------
+# Processor Selection
+#----------------------------------------
+
+processor.selection_strategy = $CANTALOUPE_PROCESSOR_SELECTION_STRATEGY
+
+# Video Processor Selections
+processor.ManualSelectionStrategy.avi = $CANTALOUPE_MANUAL_PROCESSOR_AVI
+processor.ManualSelectionStrategy.flv = $CANTALOUPE_MANUAL_PROCESSOR_FLV
+processor.ManualSelectionStrategy.mov = $CANTALOUPE_MANUAL_PROCESSOR_MOV
+processor.ManualSelectionStrategy.mp4 = $CANTALOUPE_MANUAL_PROCESSOR_MP4
+processor.ManualSelectionStrategy.mpg = $CANTALOUPE_MANUAL_PROCESSOR_MPG
+processor.ManualSelectionStrategy.webm = $CANTALOUPE_MANUAL_PROCESSOR_WEBM
+
+# Image Processor Selections
+processor.ManualSelectionStrategy.bmp = $CANTALOUPE_MANUAL_PROCESSOR_BMP
+processor.ManualSelectionStrategy.dcm = $CANTALOUPE_MANUAL_PROCESSOR_DCM
+processor.ManualSelectionStrategy.gif = $CANTALOUPE_MANUAL_PROCESSOR_GIF
+processor.ManualSelectionStrategy.jp2 = $CANTALOUPE_MANUAL_PROCESSOR_JP2
+processor.ManualSelectionStrategy.jpg = $CANTALOUPE_MANUAL_PROCESSOR_JPG
+processor.ManualSelectionStrategy.pdf = $CANTALOUPE_MANUAL_PROCESSOR_PDF
+processor.ManualSelectionStrategy.png = $CANTALOUPE_MANUAL_PROCESSOR_PNG
+processor.ManualSelectionStrategy.tif = $CANTALOUPE_MANUAL_PROCESSOR_TIF
+processor.ManualSelectionStrategy.webp = $CANTALOUPE_MANUAL_PROCESSOR_WEBP
+
+
+# Fall back to this processor for any formats not assigned above.
+processor.ManualSelectionStrategy.fallback = $CANTALOUPE_PROCESSOR_FALLBACK
+
+#----------------------------------------
+# Global Processor Configuration
+#----------------------------------------
+
+processor.stream_retrieval_strategy = $CANTALOUPE_PROCESSOR_STREAM_RETRIEVAL_STRATEGY
+processor.fallback_retrieval_strategy = $CANTALOUPE_PROCESSOR_FALLBACK_RETRIEVAL_STRATEGY
+processor.dpi = $CANTALOUPE_PROCESSOR_DPI
+#processor.normalize = $CANTALOUPE_PROCESSOR_NORMALIZE
+processor.background_color = $CANTALOUPE_PROCESSOR_BACKGROUND_COLOR
+processor.downscale_filter = $CANTALOUPE_PROCESSOR_DOWNSCALE_FILTER
+processor.upscale_filter = $CANTALOUPE_PROCESSOR_UPSCALE_FILTER
+processor.sharpen = $CANTALOUPE_PROCESSOR_SHARPEN
+processor.metadata.preserve = $CANTALOUPE_PROCESSOR_METADATA_PRESERVE
+processor.metadata.respect_orientation = $CANTALOUPE_PROCESSOR_METADATA_RESPECT_ORIENTATION
+processor.jpg.progressive = $CANTALOUPE_PROCESSOR_JPG_PROGRESSIVE
+processor.jpg.quality = $CANTALOUPE_PROCESSOR_JPG_QUALITY
+processor.tif.compression = $CANTALOUPE_PROCESSOR_TIF_COMPRESSION
+
+#----------------------------------------
+# ImageIO Plugin Preferences
+#----------------------------------------
+
+processor.imageio.bmp.reader = $CANTALOUPE_PROCESSOR_IMAGEIO_BMP_READER
+processor.imageio.gif.reader = $CANTALOUPE_PROCESSOR_IMAGEIO_GIF_READER
+processor.imageio.gif.writer = $CANTALOUPE_PROCESSOR_IMAGEIO_GIF_WRITER
+processor.imageio.jpg.reader = $CANTALOUPE_PROCESSOR_IMAGEIO_JPG_READER
+processor.imageio.jpg.writer = $CANTALOUPE_PROCESSOR_IMAGEIO_JPG_WRITER
+processor.imageio.png.reader = $CANTALOUPE_PROCESSOR_IMAGEIO_PNG_READER
+processor.imageio.png.writer = $CANTALOUPE_PROCESSOR_IMAGEIO_PNG_WRITER
+processor.imageio.tif.reader = $CANTALOUPE_PROCESSOR_IMAGEIO_TIF_READER
+processor.imageio.tif.writer = $CANTALOUPE_PROCESSOR_IMAGEIO_TIF_WRITER
+
+#----------------------------------------
+# FfmpegProcessor
+#----------------------------------------
+
+FfmpegProcessor.path_to_binaries = $CANTALOUPE_FFMPEGPROCESSOR_PATH_TO_BINARIES
+
+#----------------------------------------
+# GraphicsMagickProcessor
+#----------------------------------------
+
+GraphicsMagickProcessor.path_to_binaries = $CANTALOUPE_GRAPHICSMAGICKPROCESSOR_PATH_TO_BINARIES
+
+#----------------------------------------
+# ImageMagickProcessor
+#----------------------------------------
+
+ImageMagickProcessor.path_to_binaries = $CANTALOUPE_IMAGEMAGICKPROCESSOR_PATH_TO_BINARIES
+
+#----------------------------------------
+# KakaduDemoProcessor
+#----------------------------------------
+
+KakaduDemoProcessor.path_to_binaries = $CANTALOUPE_KAKADUDEMOPROCESSOR_PATH_TO_BINARIES
+
+#----------------------------------------
+# OpenJpegProcessor
+#----------------------------------------
+
+OpenJpegProcessor.path_to_binaries = $CANTALOUPE_OPENJPEGPROCESSOR_PATH_TO_BINARIES
+
+###########################################################################
+# CLIENT-SIDE CACHING
+###########################################################################
+
+cache.client.enabled = $CANTALOUPE_CACHE_CLIENT_ENABLED
+cache.client.max_age = $CANTALOUPE_CACHE_CLIENT_MAX_AGE
+cache.client.shared_max_age = $CANTALOUPE_CACHE_CLIENT_SHARED_MAX_AGE
+cache.client.public = $CANTALOUPE_CACHE_CLIENT_PUBLIC
+cache.client.private = $CANTALOUPE_CACHE_CLIENT_PRIVATE
+cache.client.no_cache = $CANTALOUPE_CACHE_CLIENT_NO_CACHE
+cache.client.no_store = $CANTALOUPE_CACHE_CLIENT_NO_STORE
+cache.client.must_revalidate = $CANTALOUPE_CACHE_CLIENT_MUST_REVALIDATE
+cache.client.proxy_revalidate = $CANTALOUPE_CACHE_CLIENT_PROXY_REVALIDATE
+cache.client.no_transform = $CANTALOUPE_CACHE_CLIENT_NO_TRANSFORM
+
+###########################################################################
+# SERVER-SIDE CACHING
+###########################################################################
+
+cache.server.source = $CANTALOUPE_CACHE_SERVER_SOURCE
+cache.server.source.ttl_seconds = $CANTALOUPE_CACHE_SERVER_SOURCE_TTL_SECONDS
+cache.server.derivative.enabled = $CANTALOUPE_CACHE_SERVER_DERIVATIVE_ENABLED
+cache.server.derivative = $CANTALOUPE_CACHE_SERVER_DERIVATIVE
+cache.server.derivative.ttl_seconds = $CANTALOUPE_CACHE_SERVER_DERIVATIVE_TTL_SECONDS
+cache.server.info.enabled = $CANTALOUPE_CACHE_SERVER_INFO_ENABLED
+cache.server.purge_missing = $CANTALOUPE_CACHE_SERVER_PURGE_MISSING
+cache.server.resolve_first = $CANTALOUPE_CACHE_SERVER_RESOLVE_FIRST
+cache.server.worker.enabled = $CANTALOUPE_CACHE_SERVER_WORKER_ENABLED
+cache.server.worker.interval = $CANTALOUPE_CACHE_SERVER_WORKER_INTERVAL
+
+#----------------------------------------
+# FilesystemCache
+#----------------------------------------
+
+FilesystemCache.pathname = $CANTALOUPE_FILESYSTEMCACHE_PATHNAME
+FilesystemCache.dir.depth = $CANTALOUPE_FILESYSTEMCACHE_DIR_DEPTH
+FilesystemCache.dir.name_length = $CANTALOUPE_FILESYSTEMCACHE_DIR_NAME_LENGTH
+
+#----------------------------------------
+# HeapCache
+#----------------------------------------
+
+HeapCache.target_size = $CANTALOUPE_HEAPCACHE_TARGET_SIZE
+HeapCache.persist = $CANTALOUPE_HEAPCACHE_PERSIST
+HeapCache.persist.filesystem.pathname = $CANTALOUPE_HEAPCACHE_PERSIST_FILESYSTEM_PATHNAME
+
+#----------------------------------------
+# JdbcCache
+#----------------------------------------
+
+JdbcCache.url = $CANTALOUPE_JDBCCACHE_URL
+JdbcCache.user = $CANTALOUPE_JDBCCACHE_USER
+JdbcCache.password = $CANTALOUPE_JDBCCACHE_PASSWORD
+JdbcCache.connection_timeout = $CANTALOUPE_JDBCCACHE_CONNECTION_TIMEOUT
+JdbcCache.derivative_image_table = $CANTALOUPE_JDBCCACHE_DERIVATIVE_IMAGE_TABLE
+JdbcCache.info_table = $CANTALOUPE_JDBCCACHE_INFO_TABLE
+
+#----------------------------------------
+# S3Cache
+#----------------------------------------
+
+S3Cache.endpoint = $CANTALOUPE_S3CACHE_ENDPOINT
+S3Cache.access_key_id = $CANTALOUPE_S3CACHE_ACCESS_KEY_ID
+S3Cache.secret_key = $CANTALOUPE_S3CACHE_SECRET_KEY
+S3Cache.bucket.name = $CANTALOUPE_S3CACHE_BUCKET_NAME
+S3Cache.object_key_prefix = $CANTALOUPE_S3CACHE_OBJECT_KEY_PREFIX
+S3Cache.max_connections = $CANTALOUPE_S3CACHE_MAX_CONNECTIONS
+
+#----------------------------------------
+# AzureStorageCache
+#----------------------------------------
+
+AzureStorageCache.account_name = $CANTALOUPE_AZURESTORAGECACHE_ACCOUNT_NAME
+AzureStorageCache.account_key = $CANTALOUPE_AZURESTORAGECACHE_ACCOUNT_KEY
+AzureStorageCache.container_name = $CANTALOUPE_AZURESTORAGECACHE_CONTAINER_NAME
+AzureStorageCache.object_key_prefix = $CANTALOUPE_AZURESTORAGECACHE_OBJECT_KEY_PREFIX
+
+#----------------------------------------
+# RedisCache
+#----------------------------------------
+
+RedisCache.host = $CANTALOUPE_REDISCACHE_HOST
+RedisCache.port = $CANTALOUPE_REDISCACHE_PORT
+RedisCache.ssl = $CANTALOUPE_REDISCACHE_SSL
+RedisCache.password = $CANTALOUPE_REDISCACHE_PASSWORD
+RedisCache.database = $CANTALOUPE_REDISCACHE_DATABASE
+
+###########################################################################
+# OVERLAYS
+###########################################################################
+
+overlays.enabled = $CANTALOUPE_OVERLAYS_ENABLED
+overlays.strategy = $CANTALOUPE_OVERLAYS_STRATEGY
+overlays.BasicStrategy.type = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_TYPE
+overlays.BasicStrategy.image = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_IMAGE
+overlays.BasicStrategy.string = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING
+overlays.BasicStrategy.string.font = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_FONT
+overlays.BasicStrategy.string.font.size = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_FONT_SIZE
+overlays.BasicStrategy.string.font.min_size = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_FONT_MIN_SIZE
+overlays.BasicStrategy.string.font.weight = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_FONT_WEIGHT
+overlays.BasicStrategy.string.glyph_spacing = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_GLYPH_SPACING
+overlays.BasicStrategy.string.color = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_COLOR
+overlays.BasicStrategy.string.stroke.color = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_STROKE_COLOR
+overlays.BasicStrategy.string.stroke.width = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_STROKE_WIDTH
+overlays.BasicStrategy.string.background.color = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_STRING_BACKGROUND_COLOR
+overlays.BasicStrategy.position = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_POSITION
+overlays.BasicStrategy.inset = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_INSET
+overlays.BasicStrategy.output_width_threshold = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_OUTPUT_WIDTH_THRESHOLD
+overlays.BasicStrategy.output_height_threshold = $CANTALOUPE_OVERLAYS_BASICSTRATEGY_OUTPUT_HEIGHT_THRESHOLD
+
+###########################################################################
+# REDACTIONS
+###########################################################################
+
+redaction.enabled = $CANTALOUPE_REDACTION_ENABLED
+
+###########################################################################
+# LOGGING
+###########################################################################
+
+#----------------------------------------
+# Application Log
+#----------------------------------------
+
+log.application.level = $CANTALOUPE_LOG_APPLICATION_LEVEL
+log.application.ConsoleAppender.enabled = $CANTALOUPE_LOG_APPLICATION_CONSOLEAPPENDER_ENABLED
+log.application.FileAppender.enabled = $CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_ENABLED
+log.application.FileAppender.pathname = $CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_PATHNAME
+log.application.RollingFileAppender.enabled = $CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_ENABLED
+log.application.RollingFileAppender.pathname = $CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_PATHNAME
+log.application.RollingFileAppender.policy = $CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_POLICY
+log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = $CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_FILENAME_PATTERN
+log.application.RollingFileAppender.TimeBasedRollingPolicy.max_history = $CANTALOUPE_LOG_APPLICATION_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_MAX_HISTORY
+log.application.SyslogAppender.enabled = $CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_ENABLED
+log.application.SyslogAppender.host = $CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_HOST
+log.application.SyslogAppender.port = $CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_PORT
+log.application.SyslogAppender.facility = $CANTALOUPE_LOG_APPLICATION_SYSLOGAPPENDER_FACILITY
+
+#----------------------------------------
+# Error Log
+#----------------------------------------
+
+log.error.FileAppender.enabled = $CANTALOUPE_LOG_ERROR_FILEAPPENDER_ENABLED
+log.error.FileAppender.pathname = $CANTALOUPE_LOG_ERROR_FILEAPPENDER_PATHNAME
+log.error.RollingFileAppender.enabled = $CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_ENABLED
+log.error.RollingFileAppender.pathname = $CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_PATHNAME
+log.error.RollingFileAppender.policy = $CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_POLICY
+log.error.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = $CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_FILENAME_PATTERN
+log.error.RollingFileAppender.TimeBasedRollingPolicy.max_history = $CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_MAX_HISTORY
+
+#----------------------------------------
+# Access Log
+#----------------------------------------
+
+log.access.ConsoleAppender.enabled = $CANTALOUPE_LOG_ACCESS_CONSOLEAPPENDER_ENABLED
+log.access.FileAppender.enabled = $CANTALOUPE_LOG_ACCESS_FILEAPPENDER_ENABLED
+log.access.FileAppender.pathname = $CANTALOUPE_LOG_ACCESS_FILEAPPENDER_PATHNAME
+log.access.RollingFileAppender.enabled = $CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_ENABLED
+log.access.RollingFileAppender.pathname = $CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_PATHNAME
+log.access.RollingFileAppender.policy = $CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_POLICY
+log.access.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = $CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_FILENAME_PATTERN
+log.access.RollingFileAppender.TimeBasedRollingPolicy.max_history = $CANTALOUPE_LOG_ACCESS_ROLLINGFILEAPPENDER_TIMEBASEDROLLINGPOLICY_MAX_HISTORY
+log.access.SyslogAppender.enabled = $CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_ENABLED
+log.access.SyslogAppender.host = $CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_HOST
+log.access.SyslogAppender.port = $CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_PORT
+log.access.SyslogAppender.facility = $CANTALOUPE_LOG_ACCESS_SYSLOGAPPENDER_FACILITY

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -73,7 +73,7 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
       end
 
       describe package('openjdk-11-jre-headless') do
-        it { is_expected.to be_installed.with_version('11.0.2+9-3ubuntu1~18.10.3') }
+        it { is_expected.to be_installed.with_version('11.0.3+7-1ubuntu2~18.10.1') }
       end
 
       describe package('wget') do
@@ -89,7 +89,7 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
       end
 
       describe package('curl') do
-        it { is_expected.to be_installed.with_version('7.61.0-1ubuntu2.3') }
+        it { is_expected.to be_installed.with_version('7.61.0-1ubuntu2.4') }
       end
 
       describe package('imagemagick') do


### PR DESCRIPTION
Unfortunately, using a standard template for 4.x.x configs in the Dockerfile is more difficult than I thought. Due to the nature of using Dockerfile's COPY command to copy the cantaloupe configs into place, we can't manipulate Docker ENVs as easily. 

I'm aware of how to do this in bash pretty easily. Docker ENV's are pretty explicit strings and can't be parsed with regex. From my perspective, it seems that we'd have to control versioning at a higher level than the Dockerfile or get away from using Docker's COPY to make this work.