### PR TITLE
Update default config source fs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If the upstream Cantaloupe project is broken, you can also build a last known go
 
  First you will need to set the environment variables required to run Cantaloupe. If you would like to test additional settings, ensure the cantaloupe.properties.tmpl template has the variable configured or you have set it as an environment variable.
 
-    docker run -d -p 8182:8182 --name melon -v testimages:/imageroot cantaloupe
+    docker run -d -p 8182:8182 --name melon -v /path/to/your/images:/imageroot cantaloupe
 
 will run the container in the background until _docker stop_ is called, looking in specified directory for image files.
 

--- a/configs/cantaloupe.properties.default-4.0.2
+++ b/configs/cantaloupe.properties.default-4.0.2
@@ -124,7 +124,7 @@ CANTALOUPE_SOURCE_DELEGATE = false
 CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
 
 ## Server-side path that will be prefixed to the identifier in the URL. Trailing slash is important!
-CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /usr/local/images/
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /imageroot/
 
 ## Server-side path or extension that will be suffixed to the identifier in the URL.
 CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX =

--- a/configs/cantaloupe.properties.default-4.0.3
+++ b/configs/cantaloupe.properties.default-4.0.3
@@ -124,7 +124,7 @@ CANTALOUPE_SOURCE_DELEGATE = false
 CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
 
 ## Server-side path that will be prefixed to the identifier in the URL. Trailing slash is important!
-CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /usr/local/images/
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /imageroot/
 
 ## Server-side path or extension that will be suffixed to the identifier in the URL.
 CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX =

--- a/configs/cantaloupe.properties.default-4.1
+++ b/configs/cantaloupe.properties.default-4.1
@@ -124,7 +124,7 @@ CANTALOUPE_SOURCE_DELEGATE = false
 CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
 
 ## Server-side path that will be prefixed to the identifier in the URL. Trailing slash is important!
-CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /usr/local/images/
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /imageroot/
 
 ## Server-side path or extension that will be suffixed to the identifier in the URL.
 CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX =

--- a/configs/cantaloupe.properties.default-4.1.1
+++ b/configs/cantaloupe.properties.default-4.1.1
@@ -136,7 +136,7 @@ CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
 
 # Server-side path that will be prefixed to the identifier in the URL.
 # Trailing slash is important!
-CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /home/myself/images/
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /imageroot/
 
 # Server-side path or extension that will be suffixed to the identifier in
 # the URL.

--- a/configs/cantaloupe.properties.default-4.1.2
+++ b/configs/cantaloupe.properties.default-4.1.2
@@ -136,7 +136,7 @@ CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
 
 # Server-side path that will be prefixed to the identifier in the URL.
 # Trailing slash is important!
-CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /home/myself/images/
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /imageroot/
 
 # Server-side path or extension that will be suffixed to the identifier in
 # the URL.

--- a/configs/cantaloupe.properties.default-dev
+++ b/configs/cantaloupe.properties.default-dev
@@ -136,7 +136,7 @@ CANTALOUPE_FILESYSTEMSOURCE_LOOKUP_STRATEGY = BasicLookupStrategy
 
 # Server-side path that will be prefixed to the identifier in the URL.
 # Trailing slash is important!
-CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /home/myself/images/
+CANTALOUPE_FILESYSTEMSOURCE_BASICLOOKUPSTRATEGY_PATH_PREFIX = /imageroot/
 
 # Server-side path or extension that will be suffixed to the identifier in
 # the URL.


### PR DESCRIPTION
We use `/imageroot/` in our documentation for the images mount inside the container, but we don't provide sane defaults in our configs for that. Update configs to use `/imagesroot/` (can always be overridden).