### PR TITLE
[IIIF-316] Set Cantaloupe to 4.1.2 and pin libturbo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # The default Cantaloupe version for our build
-ARG CANTALOUPE_VERSION="4.1.1"
+ARG CANTALOUPE_VERSION="4.1.2"
 
 # Kakadu is optional; if there it should be your licensed kakadu software directory's name
 ARG KAKADU_VERSION=
@@ -107,7 +107,7 @@ RUN apt-get update -qq && \
     libtiff5=4.0.9-6ubuntu0.2 \
     libtiff5-dev=4.0.9-6ubuntu0.2 \
     libopenjp2-tools=2.3.0-1 \
-    libturbojpeg \
+    libturbojpeg=2.0.0-0ubuntu2 \
     openjdk-11-jre-headless=11.0.3+7-1ubuntu2~18.10.1  \
     wget=1.19.5-1ubuntu1.1 \
     unzip=6.0-21ubuntu1 \

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Rudimentary containerization of the [Cantaloupe server](https://cantaloupe-proje
 
     docker build -t cantaloupe .
 
-This invocation will download the 4.1.1 (current at time of writing) release of the software. To override for
+This invocation will download the 4.1.2 (current at time of writing) release of the software. To override for
 newer (or older) versions:
 
     docker build --build-arg CANTALOUPE_VERSION=<desired version> -t cantaloupe .
 
-_Note:_ if you want to build a version other than 4.1.1, 4.1, 4.0.3, or 4.0.2 you will need to supply a Cantaloupe properties `template` and `defaults` file in the `configs` directory. These files should be named with the Cantaloupe version you are interested in building. If the version you need is close to one of the supplied version files, you can probably just copy that file and edit as appropriate.
+_Note:_ if you want to build a version other than 4.1.2, 4.1, 4.0.3, or 4.0.2 you will need to supply a Cantaloupe properties `template` and `defaults` file in the `configs` directory. These files should be named with the Cantaloupe version you are interested in building. If the version you need is close to one of the supplied version files, you can probably just copy that file and edit as appropriate.
 
 To build the latest development snapshot of Cantaloupe, use the following:
 

--- a/spec/cantaloupe_spec.rb
+++ b/spec/cantaloupe_spec.rb
@@ -12,7 +12,7 @@ docker_env = { 'ENDPOINT_ADMIN_SECRET' => 'secret', 'ENDPOINT_ADMIN_ENABLED' => 
 
 # First we build either a 'stable' or 'dev' Cantaloupe image, depending on our ENV property
 if version == 'stable'
-  expected_version = '4.1.1'
+  expected_version = '4.1.2'
   kakadu_version = ENV.key?('KAKADU_VERSION') ? ' --build-arg KAKADU_VERSION=' + ENV['KAKADU_VERSION'] : ''
 
   # Build the _stable version of cantaloupe by calling docker here via a system call
@@ -102,6 +102,10 @@ describe docker_build(dockerfile, tag: image_tag + '_test') do
 
       describe package('python') do
         it { is_expected.to be_installed.with_version('2.7.15-3') }
+      end
+
+      describe package('libturbojpeg') do
+        it { is_expected.to be_installed.with_version('2.0.0-0ubuntu2') }
       end
 
       if ENV['KAKADU_VERSION']


### PR DESCRIPTION
* Set default version of Cantaloupe to 4.1.2 for the stable build
* revise spec for stable build to verify version 4.1.2 is deployed
* Pin libturbojpeg
* revise spec to confirm the pinned version of libturbojpeg is installed