### PR TITLE
[IIIF-490] Temporary fix to remove multiple triggers

### DIFF
--- a/.travis/trigger-docker-build.sh
+++ b/.travis/trigger-docker-build.sh
@@ -5,7 +5,7 @@
 # JENKINS_USER_PASS
 # JENKINS_URL: Contains Token
 
-if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' && $CANTALOUPE_VERSION == 'stable' ]]; then
   curl -I -u "${JENKINS_USER}:${JENKINS_USER_PASS}" "${JENKINS_URL}&GIT_COMMIT_HASH=${TRAVIS_COMMIT}"
 fi
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,17 +16,6 @@ pipeline {
   stages {
     stage("Build cantaloupe-ucla") {
       parallel {
-        stage("Notify Slack Channel") {
-          steps {
-            slackSend(
-            channel: "#softwaredev-services-firehose",
-            color: "#8B0000",
-            tokenCredentialId: "95231ecb-a041-445b-84c0-870db41e2ba8",
-            teamDomain: "uclalibrary",
-            message: "${env.JOB_NAME} - #${env.BUILD_NUMBER} Started (<${env.RUN_DISPLAY_URL}|open>)\nGit Commit: ${GIT_COMMIT_HASH}"
-            )
-          }
-        }
         stage("Building stable") {
           steps {
             awsCodeBuild(


### PR DESCRIPTION
The current travis.yml setup is set to matrix off jobs. Meaning each run will cause a trigger to our Jenkins cantaloupe-ucla build. I'm currently setting a place holder to only have the stable job trigger the job.

Long term, we may we want to move this to the TravisCI jobs pipeline that bucketeer is using.