### PR TITLE
[IIIF-838] Make custom logback handle both jar and war files

### DIFF
--- a/src/main/docker/docker-entrypoint.sh
+++ b/src/main/docker/docker-entrypoint.sh
@@ -38,7 +38,7 @@ fi
 
 # If LOGBACK_URL is defined, download and insert logback.xml file into war file
 if [[ ! -z "${LOGBACK_URL}" ]]; then
-  zip -qd /usr/local/cantaloupe/cantaloupe-*.ar WEB-INF/classes/logback.xml
+  zip -qd /usr/local/cantaloupe/cantaloupe-*.*ar WEB-INF/classes/logback.xml
   cd /tmp
   mkdir -p WEB-INF/classes WEB-INF/lib
   curl -so WEB-INF/classes/logback.xml ${LOGBACK_URL}
@@ -53,7 +53,7 @@ if [[ ! -z "${LOGBACK_URL}" ]]; then
   fi
 
   # Package up the logback file and dependent jars
-  zip -qur /usr/local/cantaloupe/cantaloupe-*.ar WEB-INF
+  zip -qur /usr/local/cantaloupe/cantaloupe-*.*ar WEB-INF
 
   # Clean up scratch space
   rm -rf /tmp/WEB-INF

--- a/src/main/docker/docker-entrypoint.sh
+++ b/src/main/docker/docker-entrypoint.sh
@@ -38,7 +38,7 @@ fi
 
 # If LOGBACK_URL is defined, download and insert logback.xml file into war file
 if [[ ! -z "${LOGBACK_URL}" ]]; then
-  zip -qd /usr/local/cantaloupe/cantaloupe-*.war WEB-INF/classes/logback.xml
+  zip -qd /usr/local/cantaloupe/cantaloupe-*.ar WEB-INF/classes/logback.xml
   cd /tmp
   mkdir -p WEB-INF/classes WEB-INF/lib
   curl -so WEB-INF/classes/logback.xml ${LOGBACK_URL}
@@ -53,7 +53,7 @@ if [[ ! -z "${LOGBACK_URL}" ]]; then
   fi
 
   # Package up the logback file and dependent jars
-  zip -qur /usr/local/cantaloupe/cantaloupe-*.war WEB-INF
+  zip -qur /usr/local/cantaloupe/cantaloupe-*.ar WEB-INF
 
   # Clean up scratch space
   rm -rf /tmp/WEB-INF


### PR DESCRIPTION
Please review the full file to see the new changes. The reason we're adding jars directly into the jar/war file via entrypoint and not maven is because we don't control the pom file. That's pulled from upstream Cantaloupe.

It also turns out that Cantaloupe upstream overrides the log4j libraries with Joran libs. Meaning we can't just pass in an external logback config through parameters because Joran overrides it. We would have to modify the upstream code to resolve that issue.