### PR TITLE
[IIIF-916] Skip devBuilds except on cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
 - BUILD_TYPE="" ADDED_LIBS="-Dkakadu.version=${KAKADU_VERSION}"
 - BUILD_TYPE="-DdevBuild" ADDED_LIBS="-Dkakadu.version=${KAKADU_VERSION}"
 
+jobs:
+  exclude:
+  - if: env(BUILD_TYPE) IS present AND type != cron
+
 services:
 - docker
 


### PR DESCRIPTION
We want to run the dev builds (on the 5.x line) only as nightly cron jobs.