### PR TITLE
[IIIF-1039] Update openjdk version again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
         </property>
       </activation>
       <properties>
-        <openjdk.version>=11.0.9+11-0ubuntu1~20.04</openjdk.version>
+        <openjdk.version>=11.0.9.1+1-0ubuntu1~20.04</openjdk.version>
         <gcc.version>=4:9.3.0-1ubuntu2</gcc.version>
         <make.version>=4.2.1-1.2</make.version>
         <libtiff.version>=4.1.0+git191117-2build1</libtiff.version>


### PR DESCRIPTION
Ubuntu's openjdk version changed again so we need to fix the build by updating version again.