### PR TITLE
Have java replace the shell so signals work

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -160,4 +160,4 @@ ENV CANTALOUPE_LOG_ERROR_ROLLINGFILEAPPENDER_PATHNAME=/var/log/cantaloupe/error.
 USER cantaloupe
 WORKDIR /home/cantaloupe
 ENTRYPOINT ["docker-entrypoint.sh"]
-CMD [ "sh", "-c", "java -Dcantaloupe.config=$CONFIG_FILE -Xmx$HEAP_SIZE -jar /usr/local/cantaloupe/cantaloupe-*.*ar" ]
+CMD [ "sh", "-c", "exec java -Dcantaloupe.config=$CONFIG_FILE -Xmx$HEAP_SIZE -jar /usr/local/cantaloupe/cantaloupe-*.*ar" ]


### PR DESCRIPTION
The docker-entrypoint.sh file correctly exec's so that signals are passed to the java process, but since the java process is started with /bin/sh (so it can interpolate the $HEAP_SIZE) it needs to exec as well for the java process to be able to handle process signals.

With this PR stopping the container will immediately gracefully shut it down, whereas before it would wait until the stop timeout to be forcibly killed.

Before:
```
$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cantalo+     1  0.0  0.0   2612   608 pts/0    Ss+  01:14   0:00 sh -c java -Dcantaloupe.config=$CONFIG_FILE -Xmx$HEAP_SIZE -jar /usr/local/cantaloupe/cantalo
cantalo+    13  0.4  4.3 4713872 281260 pts/0  Sl+  01:14   0:43 java -Dcantaloupe.config=/etc/cantaloupe.properties -Xmx1024m -jar /usr/local/cantaloupe/cant
cantalo+    65  0.0  0.0   2612   604 pts/1    Ss   03:52   0:00 sh
cantalo+    73  0.0  0.0   5900  2984 pts/1    R+   03:54   0:00 ps aux
```

After:
```
$ ps aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
cantalo+     1 41.1  3.2 4702232 211936 pts/0  Ssl+ 03:59   0:13 java -Dcantaloupe.config=/etc/cantaloupe.properties -Xmx1024m -jar /usr/local/cantaloupe/cant
cantalo+    56  1.0  0.0   2612   600 pts/1    Ss   04:00   0:00 sh
cantalo+    63  0.0  0.0   5900  2904 pts/1    R+   04:00   0:00 ps aux
```