### PR TITLE
[IIIF-1104] Fix remote, non-Kakadu GHA builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           restore-keys: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
+        if: ${{ matrix.build_property }} == 'kakadu.version'
         with:
           ssh-private-key: ${{ secrets.KAKADU_PRIVATE_SSH_KEY }}
       - name: Build with Maven

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
-        if: ${{ matrix.build_property }} == 'kakadu.version'
+        if: matrix.build_property == 'kakadu.version'
         with:
           ssh-private-key: ${{ secrets.KAKADU_PRIVATE_SSH_KEY }}
       - name: Build with Maven

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
-        if: matrix.build_property == 'kakadu.version'
+        if: ${{ matrix.build_property == 'kakadu.version' }}
         with:
           ssh-private-key: ${{ secrets.KAKADU_PRIVATE_SSH_KEY }}
       - name: Build with Maven


### PR DESCRIPTION
Remote PRs fail all GHA builds because we try to install the Kakadu SSH key (for the builds that do build Kakadu). Update the GHA workflow so that the Kakadu SSH key is only installed if the build is trying to build Kakadu. This way at least non-Kakadu builds will succeed with remote PRs.