### PR TITLE
Update pinned dep versions, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To build the current stable version of Cantaloupe (i.e., 4.1.x), run:
 
 _We use `verify` instead of `package` because there are tests in the verify stage that will be run against the newly build container to make sure it's built and configured like it should be._
 
+_Hint: If the build fails, it may be because a package in the Docker image has been recently updated. To work around this, see the [Working with Pinned OS Packages](https://github.com/uclalibrary/docker-cantaloupe#working-with-pinned-os-packages) section at the bottom of this document._
+
 To build the latest development version of Cantaloupe (i.e., 5.0-SNAPSHOT), use the following:
 
     mvn verify -DdevBuild
@@ -54,7 +56,7 @@ In addition to running a test Cantaloupe server using the Maven Docker plugin, y
     docker run -d -p 8182:8182 \
       -e "CANTALOUPE_ENDPOINT_ADMIN_SECRET=secret" \
       -e "CANTALOUPE_ENDPOINT_ADMIN_ENABLED=true" \
-      --name melon -v /path/to/your/images:/imageroot cantaloupe:4.1.7-1  # or latest version
+      --name melon -v /path/to/your/images:/imageroot cantaloupe:4.1.7-3  # or latest version
 
 Here is another, more complex, example:
 
@@ -69,7 +71,7 @@ Here is another, more complex, example:
       -e "CANTALOUPE_S3SOURCE_ENDPOINT=s3.amazonaws.com" \
       -e "CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_ENABLED=true" \
       -e "CANTALOUPE_LOG_APPLICATION_FILEAPPENDER_PATHNAME=/var/log/cantaloupe/cantaloupe.log" \
-      --name melon -v /path/to/your/images:/imageroot cantaloupe:4.1.7-1  # or latest version
+      --name melon -v /path/to/your/images:/imageroot cantaloupe:4.1.7-3  # or latest version
 
 There are, of course, other ways to run Docker without having to supply all these environmental variables on the command line. One might want to use a Docker Compose file, Terraform configs, or Kubernetes.
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <openjdk.version>11.0.10+9-0ubuntu1~20.04</openjdk.version>
     <gcc.version>4:9.3.0-1ubuntu2</gcc.version>
     <make.version>4.2.1-1.2</make.version>
-    <libtiff.version>4.1.0+git191117-2build1</libtiff.version>
+    <libtiff.version>4.1.0+git191117-2ubuntu0.20.04.1</libtiff.version>
     <build.essential.version>12.8ubuntu1.1</build.essential.version>
     <libopenjp2.version>2.3.1-1ubuntu4</libopenjp2.version>
     <libturbojpeg.version>2.0.3-0ubuntu1.20.04.1</libturbojpeg.version>
@@ -83,7 +83,7 @@
     <unzip.version>6.0-25ubuntu1</unzip.version>
     <zip.version>3.0-11build1</zip.version>
     <graphicsmagick.version>1.4+really1.3.35-1</graphicsmagick.version>
-    <curl.version>7.68.0-1ubuntu2.4</curl.version>
+    <curl.version>7.68.0-1ubuntu2.5</curl.version>
     <imagemagick.version>8:6.9.10.23+dfsg-2.1ubuntu11.2</imagemagick.version>
     <ffmpeg.version>7:4.2.4-1ubuntu0.1</ffmpeg.version>
     <python2.version>2.7.17-2ubuntu4</python2.version>


### PR DESCRIPTION
* Update pinned image dependencies
* Update README to reflect latest release
* Add additional note to README about working around broken builds (b/c of pinned versions)

The security update involves libtiff. The exploit requires using a crafted TIFF image. This shouldn't be a problem for us because we control the TIFF images served through Cantaloupe, so we're not creating a new Docker release at this time. We do want to update the version, though, so that the build runs without errors.