### PR TITLE
Fix commit hash builds + bump Cantaloupe version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <!-- What versions of Cantaloupe and Kakadu are we using? -->
-    <cantaloupe.version>5.0.2</cantaloupe.version>
+    <cantaloupe.version>5.0.3</cantaloupe.version>
     <kakadu.version></kakadu.version>
 
     <!-- Git repo with Kakadu source code (ours is private; override with yours) -->

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       \
       # We can supply a particular commit ref as a defense against a broken upstream
       if [ "${cantaloupe.commit.ref}" != "latest" ] ; then \
+        git fetch --all ; \
         git checkout -b "${cantaloupe.commit.ref}" "${cantaloupe.commit.ref}" ; \
       fi && \
       \
@@ -37,9 +38,9 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
         -DartifactId="jai_imageio" -Dversion="$JAI_IMAGEIO_VERSION" -Dpackaging="jar" && \
       \
       mvn -DskipTests=true -Djar.phase=package -q clean package && \
-      mv target/cantaloupe-*-SNAPSHOT.zip "/build/Cantaloupe-${cantaloupe.version}.zip" ; \
+      mv target/cantaloupe-*.zip "/build/Cantaloupe.zip" ; \
     else \
-      curl -o "../Cantaloupe-${cantaloupe.version}.zip" -s -L \
+      curl -o "../Cantaloupe.zip" -s -L \
         "${CANTALOUPE_RELEASES}/v${cantaloupe.version}/Cantaloupe-${cantaloupe.version}.zip" ; \
     fi
 
@@ -115,13 +116,13 @@ RUN adduser --system cantaloupe
 
 # Copy work product from the Cantaloupe build into our image
 WORKDIR /tmp
-COPY --from=MAVEN_TOOL_CHAIN "/build/Cantaloupe-${cantaloupe.version}.zip" "/tmp/Cantaloupe-${cantaloupe.version}.zip"
+COPY --from=MAVEN_TOOL_CHAIN "/build/Cantaloupe.zip" "/tmp/Cantaloupe.zip"
 
 WORKDIR /usr/local
-RUN unzip -qq "/tmp/Cantaloupe-${cantaloupe.version}.zip" && \
+RUN unzip -qq "/tmp/Cantaloupe.zip" && \
     ln -s cantaloupe-?.* cantaloupe && \
     rm -rf "/tmp/Cantaloupe-${cantaloupe.version}" && \
-    rm "/tmp/Cantaloupe-${cantaloupe.version}.zip" && \
+    rm "/tmp/Cantaloupe.zip" && \
     rm -rf "/usr/local/cantaloupe-${cantaloupe.version}/deps"
 
 # Put our Kakadu libs in a directory that's in the LD_LIBRARY_PATH

--- a/src/main/generated/edu/ucla/library/iiif/cantaloupe/MessageCodes.java
+++ b/src/main/generated/edu/ucla/library/iiif/cantaloupe/MessageCodes.java
@@ -9,7 +9,7 @@ final public class MessageCodes {
 	 */
 	public static final String CAN_002 = "CAN_002";
 	/**
-	 * Message: Unexpected Cantaloupe version
+	 * Message: Unexpected Cantaloupe version: {}
 	 */
 	public static final String CAN_001 = "CAN_001";
 	/**

--- a/src/main/resources/cantaloupe_messages.xml
+++ b/src/main/resources/cantaloupe_messages.xml
@@ -11,7 +11,7 @@
 
   <!-- Messages to be stored in the MessageCodes class -->
   <entry key="CAN_000">Connecting to test instance: {}</entry>
-  <entry key="CAN_001">Unexpected Cantaloupe version</entry>
+  <entry key="CAN_001">Unexpected Cantaloupe version: {}</entry>
   <entry key="CAN_002">Couldn't get the Cantaloupe version from the test instance</entry>
   <entry key="CAN_003">Didn't find an expected Cantaloupe version in system properties</entry>
   <entry key="CAN_004">Kakadu should be installed; attempting to run Kakadu specific tests</entry>

--- a/src/test/java/edu/ucla/library/iiif/cantaloupe/Constants.java
+++ b/src/test/java/edu/ucla/library/iiif/cantaloupe/Constants.java
@@ -12,6 +12,9 @@ public final class Constants {
     /* The version of Cantaloupe that's being tested. */
     public static final String CANTALOUPE_VERSION = "cantaloupe.version";
 
+    /* The Cantaloupe commit hash that's being tested. */
+    public static final String CANTALOUPE_COMMIT_REF = "cantaloupe.commit.ref";
+
     /* The version of Kakadu that's being tested. */
     public static final String KAKADU_VERSION = "kakadu.version";
 

--- a/src/test/java/edu/ucla/library/iiif/cantaloupe/VersionIT.java
+++ b/src/test/java/edu/ucla/library/iiif/cantaloupe/VersionIT.java
@@ -40,16 +40,22 @@ public class VersionIT extends AbstractCantaloupeIT {
      */
     @Test
     public void testVersion() {
-        final Element foundVersion = myHTML.selectFirst("#container h1 small");
+        final Element foundVersionElem = myHTML.selectFirst("#container h1 small");
         final String expectedVersion = System.getProperty(Constants.CANTALOUPE_VERSION);
+        final String commitRef = System.getProperty(Constants.CANTALOUPE_COMMIT_REF);
+        final String foundVersion;
 
         assertNotNull(LOGGER.getMessage(MessageCodes.CAN_003), expectedVersion);
-        assertNotNull(LOGGER.getMessage(MessageCodes.CAN_002), foundVersion);
+        assertNotNull(LOGGER.getMessage(MessageCodes.CAN_002), foundVersionElem);
+
+        foundVersion = foundVersionElem.text();
 
         if ("dev".equals(expectedVersion)) {
-            assertTrue(LOGGER.getMessage(MessageCodes.CAN_001), foundVersion.text().contains("SNAPSHOT"));
+            if ("latest".equals(commitRef)) {
+                assertTrue(LOGGER.getMessage(MessageCodes.CAN_001, foundVersion), foundVersion.contains("SNAPSHOT"));
+            } // We skip if we're building from a commit hash; the version isn't really accurate in this case
         } else {
-            assertEquals(LOGGER.getMessage(MessageCodes.CAN_001), expectedVersion, foundVersion.text());
+            assertEquals(LOGGER.getMessage(MessageCodes.CAN_001, foundVersion), expectedVersion, foundVersion);
         }
     }
 


### PR DESCRIPTION
Bumped Cantaloupe version to the latest: 5.0.3.

We also had a request to do a "latest-dev" build to pull in a Cantaloupe fix that isn't yet released in the next version (5.0.4). This latest-dev will live in our DockerHub until 5.0.4 is released by the upstream. There was a test fix needed to use the commit hash build function again.