### PR TITLE
[SERV-332] Enable hotfix patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ To build the latest nightly build of Cantaloupe, use the following:
 
 The stable version of the build creates a Docker container with pinned versions of the pre-requisite software. The development build uses whatever the latest versions are in the base container that's used. This means, when the stable build no longer works (because the pinned versions are obsolete), the development version can still be run. Once that image is built, a person can shell into the container, see what the current versions are, and update the pinned versions in the Maven POM file accordingly.
 
+To apply your own patches to the Cantaloupe source, create a patchfile in `src/main/docker/patches` with a Git diff, then use the following:
+
+    mvn verify -DdevBuild -Dcantaloupe.patch=hotfix.patch
+
 _Hint: If you want to run a build without a Docker cache, add `-Ddocker.noCache` to your mvn command; for instance: `mvn verify -Ddocker.noCache`_
 
 ### Run the Cantaloupe container

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The stable version of the build creates a Docker container with pinned versions 
 
 To apply your own patches to the Cantaloupe source, create a patchfile in `src/main/docker/patches` with a Git diff, then use the following:
 
-    mvn verify -DdevBuild -Dcantaloupe.patch=hotfix.patch
+    mvn verify -DdevBuild -Dcantaloupe.patchfile=hotfix.patch
 
 _Hint: If you want to run a build without a Docker cache, add `-Ddocker.noCache` to your mvn command; for instance: `mvn verify -Ddocker.noCache`_
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,21 @@ _We use `verify` instead of `package` because there are tests in the verify stag
 
 _Hint: If the build fails, it may be because a package in the Docker image has been recently updated. To work around this, see the [Working with Pinned OS Packages](https://github.com/uclalibrary/docker-cantaloupe#working-with-pinned-os-packages) section at the bottom of this document._
 
-To build the latest nightly build of Cantaloupe, use the following:
+To build Cantaloupe using the latest code on [the `develop` branch](https://github.com/cantaloupe-project/cantaloupe/tree/develop) (i.e., our "nightly" build), use the following:
 
-    mvn verify -DdevBuild
+    mvn verify -Dcantaloupe.version=dev
 
 The stable version of the build creates a Docker container with pinned versions of the pre-requisite software. The development build uses whatever the latest versions are in the base container that's used. This means, when the stable build no longer works (because the pinned versions are obsolete), the development version can still be run. Once that image is built, a person can shell into the container, see what the current versions are, and update the pinned versions in the Maven POM file accordingly.
 
+To build an older version of Cantaloupe, you can specify a commit hash:
+
+    mvn verify -Dcantaloupe.version=dev -Dcantaloupe.commit.ref=fff5425
+
 To apply your own patches to the Cantaloupe source, create a patchfile in `src/main/docker/patches` with a Git diff, then use the following:
 
-    mvn verify -DdevBuild -Dcantaloupe.patchfile=hotfix.patch
+    mvn verify -Dcantaloupe.version=dev -Dcantaloupe.patchfile=hotfix.patch
+
+Patching an older version of Cantaloupe is possible as well.
 
 _Hint: If you want to run a build without a Docker cache, add `-Ddocker.noCache` to your mvn command; for instance: `mvn verify -Ddocker.noCache`_
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _We use `verify` instead of `package` because there are tests in the verify stag
 
 _Hint: If the build fails, it may be because a package in the Docker image has been recently updated. To work around this, see the [Working with Pinned OS Packages](https://github.com/uclalibrary/docker-cantaloupe#working-with-pinned-os-packages) section at the bottom of this document._
 
-To build Cantaloupe using the latest code on [the `develop` branch](https://github.com/cantaloupe-project/cantaloupe/tree/develop) (i.e., our "nightly" build), use the following:
+To build Cantaloupe using the latest code on [the upstream `develop` branch](https://github.com/cantaloupe-project/cantaloupe/tree/develop) (i.e., our "nightly" build), use the following:
 
     mvn verify -Dcantaloupe.version=dev
 

--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,7 @@
       <properties>
         <cantaloupe.version>dev</cantaloupe.version>
         <cantaloupe.commit.ref>latest</cantaloupe.commit.ref>
+        <cantaloupe.patch></cantaloupe.patch>
 
         <!-- Registry account, if supplied, must end in a slash (e.g. "account/"); all deploys are 'nightly' -->
         <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:nightly</docker.image>

--- a/pom.xml
+++ b/pom.xml
@@ -629,6 +629,7 @@
       </activation>
       <properties>
         <cantaloupe.commit.ref></cantaloupe.commit.ref>
+        <cantaloupe.patch></cantaloupe.patch>
 
         <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
         <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:%v</docker.image>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <!-- Docker container dependency versions -->
     <!-- https://packages.ubuntu.com/search?keywords=search -->
     <ubuntu.tag>20.04</ubuntu.tag>
-    <openjdk.version>11.0.11+9-0ubuntu2~20.04</openjdk.version>
+    <openjdk.version>11.0.13+8-0ubuntu1~20.04</openjdk.version>
     <gcc.version>4:9.3.0-1ubuntu2</gcc.version>
     <make.version>4.2.1-1.2</make.version>
     <libtiff.version>4.1.0+git191117-2ubuntu0.20.04.2</libtiff.version>

--- a/pom.xml
+++ b/pom.xml
@@ -627,6 +627,8 @@
         </property>
       </activation>
       <properties>
+        <cantaloupe.commit.ref></cantaloupe.commit.ref>
+
         <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
         <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:%v</docker.image>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -612,7 +612,7 @@
       <properties>
         <cantaloupe.version>dev</cantaloupe.version>
         <cantaloupe.commit.ref>latest</cantaloupe.commit.ref>
-        <cantaloupe.patch></cantaloupe.patch>
+        <cantaloupe.patchfile></cantaloupe.patchfile>
 
         <!-- Registry account, if supplied, must end in a slash (e.g. "account/"); all deploys are 'nightly' -->
         <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:nightly</docker.image>
@@ -629,7 +629,7 @@
       </activation>
       <properties>
         <cantaloupe.commit.ref></cantaloupe.commit.ref>
-        <cantaloupe.patch></cantaloupe.patch>
+        <cantaloupe.patchfile></cantaloupe.patchfile>
 
         <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
         <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:%v</docker.image>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -16,6 +16,7 @@ ENV JAI_IMAGEIO_VERSION="1.1"
 ENV JAI_REPO="https://nexus.geomatys.com/repository/geotoolkit/javax/media"
 
 WORKDIR /build/cantaloupe
+COPY patches /build/patches
 RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       git clone --quiet https://github.com/cantaloupe-project/cantaloupe.git . && \
       \
@@ -23,6 +24,11 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       if [ -n "${cantaloupe.commit.ref}" -a "${cantaloupe.commit.ref}" != "latest" ] ; then \
         git fetch --all ; \
         git checkout -b "${cantaloupe.commit.ref}" "${cantaloupe.commit.ref}" ; \
+      fi && \
+      \
+      # We can also supply a patchfile as a defense against a broken upstream
+      if [ -f "/build/patches/${cantaloupe.patch}" ] ; then \
+        git apply "/build/patches/${cantaloupe.patch}" ; \
       fi && \
       \
       # Janky, but third party repos and transitive dependences... what can you do?

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -27,11 +27,11 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       fi && \
       \
       # We can also supply a patchfile as a defense against a broken upstream
-      if [ -n "${cantaloupe.patch}" ] ; then \
-        if [ -f "/build/cantaloupe-patches/${cantaloupe.patch}" ] ; then \
-          git apply "/build/cantaloupe-patches/${cantaloupe.patch}" ; \
+      if [ -n "${cantaloupe.patchfile}" ] ; then \
+        if [ -f "/build/cantaloupe-patches/${cantaloupe.patchfile}" ] ; then \
+          git apply "/build/cantaloupe-patches/${cantaloupe.patchfile}" ; \
         else \
-          echo "Warning: could not find patchfile \"${cantaloupe.patch}\"" ; \
+          echo "Warning: could not find patchfile \"${cantaloupe.patchfile}\"" ; \
         fi ; \
       fi && \
       \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -27,8 +27,12 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       fi && \
       \
       # We can also supply a patchfile as a defense against a broken upstream
-      if [ -f "/build/cantaloupe-patches/${cantaloupe.patch}" ] ; then \
-        git apply "/build/cantaloupe-patches/${cantaloupe.patch}" ; \
+      if [ -n "${cantaloupe.patch}" ] ; then \
+        if [ -f "/build/cantaloupe-patches/${cantaloupe.patch}" ] ; then \
+          git apply "/build/cantaloupe-patches/${cantaloupe.patch}" ; \
+        else \
+          echo "Warning: could not find patchfile \"${cantaloupe.patch}\"" ; \
+        fi ; \
       fi && \
       \
       # Janky, but third party repos and transitive dependences... what can you do?

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       git clone --quiet https://github.com/cantaloupe-project/cantaloupe.git . && \
       \
       # We can supply a particular commit ref as a defense against a broken upstream
-      if [ "${cantaloupe.commit.ref}" != "latest" ] ; then \
+      if [ -n "${cantaloupe.commit.ref}" -a "${cantaloupe.commit.ref}" != "latest" ] ; then \
         git fetch --all ; \
         git checkout -b "${cantaloupe.commit.ref}" "${cantaloupe.commit.ref}" ; \
       fi && \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -16,7 +16,7 @@ ENV JAI_IMAGEIO_VERSION="1.1"
 ENV JAI_REPO="https://nexus.geomatys.com/repository/geotoolkit/javax/media"
 
 WORKDIR /build/cantaloupe
-COPY patches /build/patches
+COPY patches /build/cantaloupe-patches
 RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       git clone --quiet https://github.com/cantaloupe-project/cantaloupe.git . && \
       \
@@ -27,8 +27,8 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       fi && \
       \
       # We can also supply a patchfile as a defense against a broken upstream
-      if [ -f "/build/patches/${cantaloupe.patch}" ] ; then \
-        git apply "/build/patches/${cantaloupe.patch}" ; \
+      if [ -f "/build/cantaloupe-patches/${cantaloupe.patch}" ] ; then \
+        git apply "/build/cantaloupe-patches/${cantaloupe.patch}" ; \
       fi && \
       \
       # Janky, but third party repos and transitive dependences... what can you do?

--- a/src/main/docker/patches/auth-http-401.patch
+++ b/src/main/docker/patches/auth-http-401.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+index 7b2c04e8d..f762a1c15 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+@@ -364,6 +364,7 @@ public abstract class AbstractResource {
+             if (code == 401) {
+                 getResponse().setHeader("WWW-Authenticate",
+                         info.getChallengeValue());
++                return true; // Should really only do this for info.json requests
+             }
+             throw new ResourceException(new Status(code));
+         }


### PR DESCRIPTION
This repo can now be used to apply hotfix patches to the Cantaloupe source. For example, the command
```bash
mvn verify -Dcantaloupe.version=dev -Dcantaloupe.patchfile=auth-http-401.patch
```
may be used to build a version of Cantaloupe that, when specified in the build for https://github.com/UCLALibrary/cantaloupe-auth-delegate/pull/12, behaves as the two currently failing integration tests expect.