### PR TITLE
[SERV-332] Add auth-http-401.patch build to GHA release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,8 @@ jobs:
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
         with:
           ssh-private-key: ${{ secrets.KAKADU_PRIVATE_SSH_KEY }}
-      - name: Release with Maven (nightly build)
+      - name: Release with Maven
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
-        if: github.event.release.tag_name == ''
         with:
           gpg_private_key: ${{ secrets.BUILD_KEY }}
           gpg_passphrase: ${{ secrets.BUILD_PASSPHRASE }}
@@ -75,25 +74,6 @@ jobs:
           maven_args: >
             -Drevision=${{ env.RELEASE_TAG }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
-            -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
-            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
-            -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
-            -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
-            -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}
-      - name: Release with Maven (auth-http-401.patch build)
-        uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
-        if: github.event.release.tag_name != ''
-        with:
-          gpg_private_key: ${{ secrets.BUILD_KEY }}
-          gpg_passphrase: ${{ secrets.BUILD_PASSPHRASE }}
-          nexus_username: ${{ secrets.SONATYPE_USERNAME }} # These are placeholders; we're publishing a Docker image
-          nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
-          maven_profiles: release
-          maven_args: >
-            -Drevision=${{ env.RELEASE_TAG }}
-            -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
-            -Dcantaloupe.version=dev
-            -Dcantaloupe.patchfile=auth-http-401.patch
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,9 @@ jobs:
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
         with:
           ssh-private-key: ${{ secrets.KAKADU_PRIVATE_SSH_KEY }}
-      - name: Release with Maven
+      - name: Release with Maven (nightly build)
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
+        if: github.event.release.tag_name == ''
         with:
           gpg_private_key: ${{ secrets.BUILD_KEY }}
           gpg_passphrase: ${{ secrets.BUILD_PASSPHRASE }}
@@ -74,6 +75,25 @@ jobs:
           maven_args: >
             -Drevision=${{ env.RELEASE_TAG }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
+            -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
+            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
+            -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
+            -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
+            -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}
+      - name: Release with Maven (auth-http-401.patch build)
+        uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
+        if: github.event.release.tag_name != ''
+        with:
+          gpg_private_key: ${{ secrets.BUILD_KEY }}
+          gpg_passphrase: ${{ secrets.BUILD_PASSPHRASE }}
+          nexus_username: ${{ secrets.SONATYPE_USERNAME }} # These are placeholders; we're publishing a Docker image
+          nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
+          maven_profiles: release
+          maven_args: >
+            -Drevision=${{ env.RELEASE_TAG }}
+            -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
+            -Dcantaloupe.version=dev
+            -Dcantaloupe.patchfile=auth-http-401.patch
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -612,7 +612,7 @@
       <properties>
         <cantaloupe.version>dev</cantaloupe.version>
         <cantaloupe.commit.ref>latest</cantaloupe.commit.ref>
-        <cantaloupe.patchfile>auth-http-401.patch</cantaloupe.patchfile>
+        <cantaloupe.patchfile></cantaloupe.patchfile>
 
         <!-- Registry account, if supplied, must end in a slash (e.g. "account/"); all deploys are 'nightly' -->
         <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:nightly</docker.image>

--- a/pom.xml
+++ b/pom.xml
@@ -612,7 +612,7 @@
       <properties>
         <cantaloupe.version>dev</cantaloupe.version>
         <cantaloupe.commit.ref>latest</cantaloupe.commit.ref>
-        <cantaloupe.patchfile></cantaloupe.patchfile>
+        <cantaloupe.patchfile>auth-http-401.patch</cantaloupe.patchfile>
 
         <!-- Registry account, if supplied, must end in a slash (e.g. "account/"); all deploys are 'nightly' -->
         <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:nightly</docker.image>

--- a/src/main/docker/patches/auth-http-401.patch
+++ b/src/main/docker/patches/auth-http-401.patch
@@ -1,12 +1,14 @@
 diff --git a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
-index 7b2c04e8d..f762a1c15 100644
+index 7b2c04e8d..7dab7ed32 100644
 --- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
 +++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
-@@ -364,6 +364,7 @@ public abstract class AbstractResource {
+@@ -364,6 +364,9 @@ public abstract class AbstractResource {
              if (code == 401) {
                  getResponse().setHeader("WWW-Authenticate",
                          info.getChallengeValue());
-+                return true; // Should really only do this for info.json requests
++                if (getRequestContext().getLocalURI().getPath().endsWith("info.json")) {
++                    return true;
++                }
              }
              throw new ResourceException(new Status(code));
          }


### PR DESCRIPTION
So that we can publish images that use the patch in an automated way.

Also updates the auth-http-401.patch to properly handle image responses.