### PR TITLE
[SERV-341] Refactor nightly build

### DIFF
--- a/.github/configs/release-drafter.yml
+++ b/.github/configs/release-drafter.yml
@@ -35,7 +35,3 @@ template: |
   ## What’s Changed
 
   $CHANGES
-
-  ## Contributors
-
-  $CONTRIBUTORS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache: maven
-      - name: Optionally, set artifact qualifier (for private builds that include Kakadu)
-        if: matrix.build_property == 'kakadu.version'
-        run: echo "ARTIFACT_QUALIFIER=-ucla" >> $GITHUB_ENV
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,4 +46,3 @@ jobs:
           maven_args: >
             -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -DlogLevel=DEBUG -DtestLogLevel=DEBUG
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
-            -Ddocker.image=cantaloupe${{ env.ARTIFACT_QUALIFIER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache: maven
+      - name: Optionally, set artifact qualifier (for private builds that include Kakadu)
+        if: matrix.build_property == 'kakadu.version'
+        run: echo "ARTIFACT_QUALIFIER=-ucla" >> $GITHUB_ENV
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
         env:
@@ -43,3 +46,4 @@ jobs:
           maven_args: >
             -V -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error -DlogLevel=DEBUG -DtestLogLevel=DEBUG
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
+            -Ddocker.image=cantaloupe${{ env.ARTIFACT_QUALIFIER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,10 @@ on:
     branches:
       - main
 
-  schedule:
-    - cron:  '20 10 * * *' 
-
 jobs:
   build:
     name: Maven PR Builder (JDK ${{ matrix.java }} with ${{ matrix.build_property }})
     runs-on: ubuntu-latest
-    env:
-      MAVEN_CACHE_KEY: ${{ secrets.MAVEN_CACHE_KEY }}
     strategy:
       matrix:
         java: [ 11, 17 ]
@@ -27,19 +22,7 @@ jobs:
         uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1
         with:
           java-version: ${{ matrix.java }}
-      # If running locally in act, install Maven
-      - name: Set up Maven if needed
-        if: ${{ env.ACT }}
-        uses: stCarolas/setup-maven@1d56b37995622db66cce1214d81014b09807fb5a # v4
-        with:
-          maven-version: 3.6.3
-      - name: Set up Maven cache
-        uses: actions/cache@0781355a23dac32fd3bac414512f4b903437991a # v2
-        if: ${{ env.MAVEN_CACHE_KEY }}
-        with:
-          path: ~/.m2
-          key: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: uclalibrary-cache-${{ secrets.MAVEN_CACHE_KEY }}-
+          cache: maven
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache: maven
+      - name: Optionally, set artifact qualifier (for private builds that include Kakadu)
+        if: matrix.build_property == 'kakadu.version'
+        run: echo "ARTIFACT_QUALIFIER=${{ secrets.ARTIFACT_QUALIFIER }}" >> $GITHUB_ENV
       - name: Optionally, login to Docker repository
         uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
         env:
@@ -51,7 +54,7 @@ jobs:
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=true
-            -Ddocker.image=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:nightly
+            -Ddocker.image=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}cantaloupe${{ env.ARTIFACT_QUALIFIER }}:nightly
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,12 @@
-name: Maven Build for Release
+name: Maven Build for Snapshot
 
-# Performs a Maven release using JDK 11 when a new GitHub release has been published
+# Performs a Maven release using JDK 11 on a schedule
 on:
   release:
     types: [ published ]
+
+  schedule:
+    - cron:  '20 20 * * *'
 
 jobs:
   publish:
@@ -49,11 +52,14 @@ jobs:
           nexus_username: ${{ secrets.SONATYPE_USERNAME }} # These are placeholders; we're publishing a Docker image
           nexus_password: ${{ secrets.SONATYPE_PASSWORD }}
           maven_args: >
-            -Drevision=${{ github.event.release.tag_name }}
+            -Drevision=nightly
+            -Dcantaloupe.version=dev
+            -Dcantaloupe.commit.ref=latest
+            -Dcantaloupe.patchfile=auth-http-401.patch
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
-            -Ddocker.image=uclalibrary/cantaloupe${{ env.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
+            -Ddocker.image=uclalibrary/cantaloupe${{ env.ARTIFACT_QUALIFIER }}:nightly
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,8 +12,6 @@ jobs:
   publish:
     name: Maven Artifact Publisher (JDK ${{ matrix.java }} with ${{ matrix.build_property }})
     runs-on: ubuntu-latest
-    env:
-      SKIP_JAR_DEPLOYMENT: ${{ secrets.SKIP_JAR_DEPLOYMENT }}
     strategy:
       matrix:
         java: [ 11 ]
@@ -26,9 +24,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache: maven
-      - name: Set Jar deployment config
-        if: env.SKIP_JAR_DEPLOYMENT == null
-        run: echo "SKIP_JAR_DEPLOYMENT=false" >> $GITHUB_ENV
       - name: Optionally, login to Docker repository
         uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
         env:
@@ -55,7 +50,7 @@ jobs:
             -Dcantaloupe.patchfile=auth-http-401.patch
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
-            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
+            -DskipNexusStagingDeployMojo=true
             -Ddocker.image=uclalibrary/cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:nightly
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=true
-            -Ddocker.image=uclalibrary/cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:nightly
+            -Ddocker.image=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:nightly
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,9 +37,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Optionally, set artifact qualifier (for private builds that include Kakadu)
-        if: matrix.build_property == 'kakadu.version'
-        run: echo "ARTIFACT_QUALIFIER=-ucla" >> $GITHUB_ENV
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
         with:
@@ -59,7 +56,7 @@ jobs:
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
-            -Ddocker.image=uclalibrary/cantaloupe${{ env.ARTIFACT_QUALIFIER }}:nightly
+            -Ddocker.image=uclalibrary/cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:nightly
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
   publish:
     name: Maven Artifact Publisher (JDK ${{ matrix.java }} with ${{ matrix.build_property }})
     runs-on: ubuntu-latest
-    env:
-      SKIP_JAR_DEPLOYMENT: ${{ secrets.SKIP_JAR_DEPLOYMENT }}
     strategy:
       matrix:
         java: [ 11 ]
@@ -23,9 +21,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache: maven
-      - name: Set Jar deployment config
-        if: env.SKIP_JAR_DEPLOYMENT == null
-        run: echo "SKIP_JAR_DEPLOYMENT=false" >> $GITHUB_ENV
       - name: Optionally, login to Docker repository
         uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
         env:
@@ -49,7 +44,7 @@ jobs:
             -Drevision=${{ github.event.release.tag_name }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
-            -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
+            -DskipNexusStagingDeployMojo=true
             -Ddocker.image=uclalibrary/cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=true
-            -Ddocker.image=uclalibrary/cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
+            -Ddocker.image=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           cache: maven
+      - name: Optionally, set artifact qualifier (for private builds that include Kakadu)
+        if: matrix.build_property == 'kakadu.version'
+        run: echo "ARTIFACT_QUALIFIER=${{ secrets.ARTIFACT_QUALIFIER }}" >> $GITHUB_ENV
       - name: Optionally, login to Docker repository
         uses: docker/login-action@f3364599c6aa293cdc2b8391b1b56d0c30e45c8a # v1.8.0
         env:
@@ -45,7 +48,7 @@ jobs:
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=true
-            -Ddocker.image=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
+            -Ddocker.image=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}cantaloupe${{ env.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Optionally, set artifact qualifier (for private builds that include Kakadu)
-        if: matrix.build_property == 'kakadu.version'
-        run: echo "ARTIFACT_QUALIFIER=-ucla" >> $GITHUB_ENV
       - name: Install Kakadu SSH key
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e # v0.4.1
         with:
@@ -53,7 +50,7 @@ jobs:
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
             -DskipNexusStagingDeployMojo=${{ env.SKIP_JAR_DEPLOYMENT }}
-            -Ddocker.image=uclalibrary/cantaloupe${{ env.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
+            -Ddocker.image=uclalibrary/cantaloupe${{ secrets.ARTIFACT_QUALIFIER }}:${{ github.event.release.tag_name }}
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,6 @@
     <!-- The registry account, if supplied, must end with a slash (e.g. "account/") -->
     <docker.registry.account />
 
-    <!-- The artifact is qualified if it's built with Kakadu -->
-    <artifact.qualifier></artifact.qualifier>
-
     <!-- Additional Docker configurations -->
     <docker.cleanup>remove</docker.cleanup>
     <docker.showLogs>true</docker.showLogs>
@@ -519,9 +516,6 @@
           <name>kakadu.version</name>
         </property>
       </activation>
-      <properties>
-        <artifact.qualifier>-ucla</artifact.qualifier>
-      </properties>
       <build>
         <plugins>
           <plugin>
@@ -599,41 +593,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <!-- A profile that builds the image with a development version of Cantaloupe -->
-    <profile>
-      <id>devBuild</id>
-      <activation>
-        <property>
-          <name>devBuild</name>
-        </property>
-      </activation>
-      <properties>
-        <cantaloupe.version>dev</cantaloupe.version>
-        <cantaloupe.commit.ref>latest</cantaloupe.commit.ref>
-        <cantaloupe.patchfile>auth-http-401.patch</cantaloupe.patchfile>
-
-        <!-- Registry account, if supplied, must end in a slash (e.g. "account/"); all deploys are 'nightly' -->
-        <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:nightly</docker.image>
-      </properties>
-    </profile>
-
-    <!-- A profile that builds the image with a released version of Cantaloupe -->
-    <profile>
-      <id>default</id>
-      <activation>
-        <property>
-          <name>!devBuild</name>
-        </property>
-      </activation>
-      <properties>
-        <cantaloupe.commit.ref></cantaloupe.commit.ref>
-        <cantaloupe.patchfile></cantaloupe.patchfile>
-
-        <!-- Registry account, if supplied, must end in a slash (e.g. "account/") -->
-        <docker.image>${docker.registry.account}${project.artifactId}${artifact.qualifier}:%v</docker.image>
-      </properties>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
   <properties>
     <!-- What versions of Cantaloupe and Kakadu are we using? -->
     <cantaloupe.version>5.0.4</cantaloupe.version>
+    <cantaloupe.commit.ref></cantaloupe.commit.ref>
+    <cantaloupe.patchfile></cantaloupe.patchfile>
     <kakadu.version></kakadu.version>
 
     <!-- Git repo with Kakadu source code (ours is private; override with yours) -->

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,12 @@
     <!-- The registry account, if supplied, must end with a slash (e.g. "account/") -->
     <docker.registry.account />
 
+    <!-- The artifact is qualified if it's built with Kakadu -->
+    <artifact.qualifier></artifact.qualifier>
+
     <!-- Additional Docker configurations -->
     <docker.cleanup>remove</docker.cleanup>
+    <docker.image>cantaloupe${artifact.qualifier}</docker.image>
     <docker.showLogs>true</docker.showLogs>
 
     <!-- We don't need to build the jar outside of the Docker build -->
@@ -516,6 +520,9 @@
           <name>kakadu.version</name>
         </property>
       </activation>
+      <properties>
+        <artifact.qualifier>-ucla</artifact.qualifier>
+      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Per discussion with @ksclarke, I've removed the `devBuild` profile in
favor of passing the Maven properties directly, and split the nightly
build workflow off on its own. Since that profile set a `docker.image`
property, I've reproduced that logic in GHA. Since the `default` profile
referenced `devBuild`, it felt appropriate to remove it as well (and
likewise move the logic for constructing the Docker image ID for
"release" builds into GHA as well). Also simplifies the Maven cache
setup using the pattern @DRickard uses in `laptop_availability`.
