### PR TITLE
Bump pinned OpenJDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <!-- Docker container dependency versions -->
     <!-- https://packages.ubuntu.com/search?keywords=search -->
     <ubuntu.tag>20.04</ubuntu.tag>
-    <openjdk.version>11.0.13+8-0ubuntu1~20.04</openjdk.version>
+    <openjdk.version>11.0.14+9-0ubuntu2~20.04</openjdk.version>
     <gcc.version>4:9.3.0-1ubuntu2</gcc.version>
     <make.version>4.2.1-1.2</make.version>
     <libtiff.version>4.1.0+git191117-2ubuntu0.20.04.2</libtiff.version>


### PR DESCRIPTION
Resolves the nightly build failure.