### PR TITLE
[SERV-387] Add patch for cantaloupe#574

### DIFF
--- a/src/main/docker/patches/issue-574-v5.0.5.patch
+++ b/src/main/docker/patches/issue-574-v5.0.5.patch
@@ -1,0 +1,202 @@
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+index 20181b298..b479e2e29 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+@@ -198,7 +198,10 @@ public abstract class AbstractResource {
+         doGET();
+     }
+ 
+-    final void doOPTIONS() {
++    /**
++     * May be overridden by implementations that support {@literal OPTIONS}.
++     */
++    protected void doOPTIONS() {
+         Method[] methods = getSupportedMethods();
+         if (methods.length > 0) {
+             response.setStatus(Status.NO_CONTENT.getCode());
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
+index c0842269c..537c6dbad 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
+@@ -1,8 +1,10 @@
+ package edu.illinois.library.cantaloupe.resource.iiif.v1;
+ 
++import java.util.Arrays;
+ import java.util.HashSet;
+ import java.util.List;
+ import java.util.Set;
++import java.util.stream.Collectors;
+ 
+ import edu.illinois.library.cantaloupe.http.Method;
+ import edu.illinois.library.cantaloupe.http.Status;
+@@ -15,6 +17,8 @@ import edu.illinois.library.cantaloupe.resource.InformationRequestHandler;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
++import javax.servlet.http.HttpServletResponse;
++
+ /**
+  * Handles IIIF Image API 1.x information requests.
+  *
+@@ -39,6 +43,21 @@ public class InformationResource extends IIIF1Resource {
+         return SUPPORTED_METHODS;
+     }
+ 
++    @Override
++    protected final void doOPTIONS() {
++        HttpServletResponse response = getResponse();
++        Method[] methods = getSupportedMethods();
++        if (methods.length > 0) {
++            response.setStatus(Status.NO_CONTENT.getCode());
++            response.setHeader("Access-Control-Allow-Headers", "Authorization");
++            response.setHeader("Allow", Arrays.stream(methods)
++                    .map(Method::toString)
++                    .collect(Collectors.joining(",")));
++        } else {
++            response.setStatus(Status.METHOD_NOT_ALLOWED.getCode());
++        }
++    }
++
+     /**
+      * Writes a JSON-serialized {@link ImageInfo} instance to the response.
+      */
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
+index bc3658f7f..78051e72a 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
+@@ -1,8 +1,10 @@
+ package edu.illinois.library.cantaloupe.resource.iiif.v2;
+ 
++import java.util.Arrays;
+ import java.util.HashSet;
+ import java.util.List;
+ import java.util.Set;
++import java.util.stream.Collectors;
+ 
+ import edu.illinois.library.cantaloupe.http.Method;
+ import edu.illinois.library.cantaloupe.http.Status;
+@@ -16,6 +18,8 @@ import edu.illinois.library.cantaloupe.resource.InformationRequestHandler;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
++import javax.servlet.http.HttpServletResponse;
++
+ /**
+  * Handles IIIF Image API 2.x information requests.
+  *
+@@ -40,6 +44,21 @@ public class InformationResource extends IIIF2Resource {
+         return SUPPORTED_METHODS;
+     }
+ 
++    @Override
++    protected final void doOPTIONS() {
++        HttpServletResponse response = getResponse();
++        Method[] methods = getSupportedMethods();
++        if (methods.length > 0) {
++            response.setStatus(Status.NO_CONTENT.getCode());
++            response.setHeader("Access-Control-Allow-Headers", "Authorization");
++            response.setHeader("Allow", Arrays.stream(methods)
++                    .map(Method::toString)
++                    .collect(Collectors.joining(",")));
++        } else {
++            response.setStatus(Status.METHOD_NOT_ALLOWED.getCode());
++        }
++    }
++
+     /**
+      * Writes a JSON-serialized {@link ImageInfo} instance to the response.
+      */
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
+index 113883d08..aed0e896d 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
+@@ -1,8 +1,10 @@
+ package edu.illinois.library.cantaloupe.resource.iiif.v3;
+ 
++import java.util.Arrays;
+ import java.util.HashSet;
+ import java.util.List;
+ import java.util.Set;
++import java.util.stream.Collectors;
+ 
+ import edu.illinois.library.cantaloupe.http.Method;
+ import edu.illinois.library.cantaloupe.http.Status;
+@@ -16,6 +18,8 @@ import edu.illinois.library.cantaloupe.resource.InformationRequestHandler;
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ 
++import javax.servlet.http.HttpServletResponse;
++
+ /**
+  * Handles IIIF Image API 3.x information requests.
+  *
+@@ -40,6 +44,21 @@ public class InformationResource extends IIIF3Resource {
+         return SUPPORTED_METHODS;
+     }
+ 
++    @Override
++    protected final void doOPTIONS() {
++        HttpServletResponse response = getResponse();
++        Method[] methods = getSupportedMethods();
++        if (methods.length > 0) {
++            response.setStatus(Status.NO_CONTENT.getCode());
++            response.setHeader("Access-Control-Allow-Headers", "Authorization");
++            response.setHeader("Allow", Arrays.stream(methods)
++                    .map(Method::toString)
++                    .collect(Collectors.joining(",")));
++        } else {
++            response.setStatus(Status.METHOD_NOT_ALLOWED.getCode());
++        }
++    }
++
+     /**
+      * Writes a JSON-serialized {@link ImageInfo} instance to the response.
+      */
+diff --git a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
+index a37df660a..885af5b4b 100644
+--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
++++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
+@@ -586,6 +586,11 @@ public class InformationResourceTest extends ResourceTest {
+         assertEquals(2, methods.size());
+         assertTrue(methods.contains("GET"));
+         assertTrue(methods.contains("OPTIONS"));
++
++        List<String> allowedHeaders =
++                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Headers"), ", "));
++        assertEquals(1, allowedHeaders.size());
++        assertTrue(allowedHeaders.contains("Authorization"));
+     }
+ 
+     @Test
+diff --git a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
+index c8f879830..405db7088 100644
+--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
++++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
+@@ -599,6 +599,11 @@ public class InformationResourceTest extends ResourceTest {
+         assertEquals(2, methods.size());
+         assertTrue(methods.contains("GET"));
+         assertTrue(methods.contains("OPTIONS"));
++
++        List<String> allowedHeaders =
++                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Headers"), ", "));
++        assertEquals(1, allowedHeaders.size());
++        assertTrue(allowedHeaders.contains("Authorization"));
+     }
+ 
+     @Test
+diff --git a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
+index e3bfc5d53..a99f2ad53 100644
+--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
++++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
+@@ -574,6 +574,11 @@ public class InformationResourceTest extends ResourceTest {
+         assertEquals(2, methods.size());
+         assertTrue(methods.contains("GET"));
+         assertTrue(methods.contains("OPTIONS"));
++
++        List<String> allowedHeaders =
++                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Headers"), ", "));
++        assertEquals(1, allowedHeaders.size());
++        assertTrue(allowedHeaders.contains("Authorization"));
+     }
+ 
+     @Test


### PR DESCRIPTION
Source code for the patch is available at https://github.com/UCLALibrary/cantaloupe/tree/bugfix/xhr-allow-authorization-header (which is the source branch for a currently-open upstream PR).