### PR TITLE
[SERV-479] Dial down the logging output

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,3 +51,4 @@ jobs:
             -Dcantaloupe.version=dev
             -Dcantaloupe.commit.ref=${{ secrets.DEV_COMMIT_REF }}
             -Dcantaloupe.apply.patchfiles=${{ secrets.APPLY_PATCHFILES }}
+            -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,3 +52,9 @@ jobs:
             -Dcantaloupe.commit.ref=${{ secrets.DEV_COMMIT_REF }}
             -Dcantaloupe.apply.patchfiles=${{ secrets.APPLY_PATCHFILES }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
+            -DskipNexusStagingDeployMojo=true
+            -D${{ matrix.build_property }}=${{ secrets.KAKADU_VERSION }}
+            -Ddocker.image=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}cantaloupe${{ env.ARTIFACT_QUALIFIER }}:nightly
+            -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
+            -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
+            -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
* We don't need to see Maven's dependency download logging and it causes problems with GA displays
* Update nightly build's Docker push configuration (it looks like now it's trying to push to cantaloupe without the `uclalibrary/` org prefix (https://github.com/UCLALibrary/docker-cantaloupe/runs/7101431164?check_suite_focus=true#step:7:2704)