### PR TITLE
Update container package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
     <build.essential.version>12.8ubuntu1.1</build.essential.version>
     <libopenjp2.version>2.3.1-1ubuntu4.20.04.1</libopenjp2.version>
     <libturbojpeg.version>2.0.3-0ubuntu1.20.04.3</libturbojpeg.version>
-    <unzip.version>6.0-25ubuntu1</unzip.version>
+    <unzip.version>6.0-25ubuntu1.1</unzip.version>
     <zip.version>3.0-11build1</zip.version>
-    <curl.version>7.68.0-1ubuntu2.13</curl.version>
+    <curl.version>7.68.0-1ubuntu2.14</curl.version>
     <ffmpeg.version>7:4.2.7-0ubuntu0.1</ffmpeg.version>
     <python2.version>2.7.17-2ubuntu4</python2.version>
     <grok.version>9.1.0</grok.version>


### PR DESCRIPTION
Minor version bumps of container packages. The packages are just used for building, not for serving images.