### PR TITLE
Patches for issue 548 and 550

### DIFF
--- a/src/main/docker/patches/issue-548-v5.0.5.patch
+++ b/src/main/docker/patches/issue-548-v5.0.5.patch
@@ -1,0 +1,53 @@
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/image/Metadata.java b/src/main/java/edu/illinois/library/cantaloupe/image/Metadata.java
+index c4e2d413a..2c7d54ddb 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/image/Metadata.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/image/Metadata.java
+@@ -5,7 +5,9 @@
+ import com.fasterxml.jackson.annotation.JsonInclude;
+ import com.fasterxml.jackson.annotation.JsonProperty;
+ import edu.illinois.library.cantaloupe.Application;
++import edu.illinois.library.cantaloupe.image.exif.DataType;
+ import edu.illinois.library.cantaloupe.image.exif.Directory;
++import edu.illinois.library.cantaloupe.image.exif.Field;
+ import edu.illinois.library.cantaloupe.image.exif.Tag;
+ import edu.illinois.library.cantaloupe.image.iptc.DataSet;
+ import edu.illinois.library.cantaloupe.util.StringUtils;
+@@ -152,9 +154,17 @@ public Orientation getOrientation() {
+     }
+ 
+     private void readOrientationFromEXIF() {
++        Field field = exif.getField(Tag.ORIENTATION);
+         Object value = exif.getValue(Tag.ORIENTATION);
+-        if (value != null) {
+-            orientation = Orientation.forEXIFOrientation((int) value);
++        if (field != null && value != null) {
++            switch (field.getDataType()) {
++              case LONG:
++                orientation = Orientation.forEXIFOrientation(Math.toIntExact((long) value));
++                break;
++              case SHORT:
++                orientation = Orientation.forEXIFOrientation((int) value);
++                break;
++            }
+         }
+     }
+ 
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/image/exif/Directory.java b/src/main/java/edu/illinois/library/cantaloupe/image/exif/Directory.java
+index c421ae259..193397d44 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/image/exif/Directory.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/image/exif/Directory.java
+@@ -170,6 +170,14 @@ public Object getValue(Tag tag) {
+                 .orElse(null);
+     }
+ 
++    public Field getField(Tag tag) {
++        return fields.keySet()
++                .stream()
++                .filter(f -> f.getTag().equals(tag))
++                .findFirst()
++                .orElse(null);
++    }
++
+     @Override
+     public int hashCode() {
+         final Map<Integer,Integer> codes = new HashMap<>();

--- a/src/main/docker/patches/issue-548-v5.0.5.patch
+++ b/src/main/docker/patches/issue-548-v5.0.5.patch
@@ -25,7 +25,7 @@ index c4e2d413a..2c7d54ddb 100644
 +              case LONG:
 +                orientation = Orientation.forEXIFOrientation(Math.toIntExact((long) value));
 +                break;
-+              case SHORT:
++              default:
 +                orientation = Orientation.forEXIFOrientation((int) value);
 +                break;
 +            }

--- a/src/main/docker/patches/issue-550-v5.0.5.patch
+++ b/src/main/docker/patches/issue-550-v5.0.5.patch
@@ -1,0 +1,15 @@
+diff --git a/src/main/java/edu/illinois/library/cantaloupe/image/exif/Reader.java b/src/main/java/edu/illinois/library/cantaloupe/image/exif/Reader.java
+index bc4261823..bafbc4084 100644
+--- a/src/main/java/edu/illinois/library/cantaloupe/image/exif/Reader.java
++++ b/src/main/java/edu/illinois/library/cantaloupe/image/exif/Reader.java
+@@ -157,6 +157,10 @@ private byte[] readBytes(int length) throws IOException {
+         byte[] data = new byte[length];
+         int n, offset = 0;
+         while ((n = inputStream.read(data, offset, data.length - offset)) < offset) {
++            if (n == -1) {
++                LOGGER.trace("readBytes(): No more data to read");
++                break;
++            }
+             offset += n;
+         }
+         return data;


### PR DESCRIPTION
Adds patches for https://github.com/cantaloupe-project/cantaloupe/issues/548 and https://github.com/cantaloupe-project/cantaloupe/issues/550, since upstream is stuck without releases since December 2021.

NB: These are generated from respective PRs by adding `.diff` to the PR URL. Not tested by me, but the patches look good and apply to branch https://github.com/cantaloupe-project/cantaloupe/tree/release/5.0

I'm experiencing issue 548 all the time and it blocks my project.