### PR TITLE
Support multi platform Docker build (buildx)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,13 @@ jobs:
         uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:
           ssh-private-key: ${{ secrets.KAKADU_PRIVATE_SSH_KEY }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
       - name: Release with Maven
         uses: samuelmeuli/action-maven-publish@201a45a3f311b2ee888f252ba9f4194257545709 # v1.4.0
         with:
@@ -58,4 +65,5 @@ jobs:
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}
+            -Ddocker.platforms=linux/amd64,linux/arm64
             -Ddocker.noCache

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ To apply your own patches to the Cantaloupe source, create patchfiles with a Git
 
 Patching an older version of Cantaloupe is possible as well.
 
+To use Docker BuildKit (i.e., buildx), supply the list of architectures to build:
+
+    mvn verify -Ddocker.platforms=linux/amd64,linux/arm64
+
 _Hint: If you want to run a build without a Docker cache, add `-Ddocker.noCache` to your mvn command; for instance: `mvn verify -Ddocker.noCache`_
 
 ### Run the Cantaloupe container
@@ -125,6 +129,8 @@ and
     mvn docker:stop -Dkakadu.version=v7_A_7-01903E
 
 You do not need to supply the `kakadu.git.repo` argument when just starting or stopping your previously built Kakadu-enabled containers. That's only needed at the point of building them.
+
+Also note: the Kakadu build only currently works with Linux x86_64 builds. We may add support for other platforms when we upgrade our Kakadu version.
 
 ### Deploying with Kubernetes
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
     <docker.cleanup>remove</docker.cleanup>
     <docker.image>cantaloupe${artifact.qualifier}</docker.image>
     <docker.showLogs>true</docker.showLogs>
+    <docker.platforms></docker.platforms>
 
     <!-- We don't need to build the jar outside of the Docker build -->
     <jar.phase></jar.phase>
@@ -134,6 +135,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>info.freelibrary</groupId>
@@ -203,9 +205,18 @@
     </testResources>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <generatedTestSourcesDirectory>src/main/generated</generatedTestSourcesDirectory>
+        </configuration>
+      </plugin>
+
       <!-- We can skip building the Jar except when Docker runs the build -->
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven.jar.version}</version>
         <executions>
           <execution>
             <id>default-jar</id>
@@ -394,6 +405,12 @@
                   <name>${docker.image}</name>
                   <build>
                     <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
+                    <buildx>
+                      <platforms>
+                        <!-- set comma separated list of platforms in ${docker.platforms} to invoke buildkit -->
+                        <platform>${docker.platforms}</platform>
+                      </platforms>
+                    </buildx>
                   </build>
                   <run>
                     <ports>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
 # The second stage of our multi-stage build builds the kakadu libraries and binaries
 FROM ubuntu:${ubuntu.tag} AS KAKADU_TOOL_CHAIN
 
-ENV JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+ENV JAVA_HOME="/usr/lib/jvm/java-17-openjdk-${TARGETARCH}"
 
 COPY kakadu /build/kakadu/
 RUN if [ ! -z "${kakadu.version}" ]; then \
@@ -71,13 +71,13 @@ RUN if [ ! -z "${kakadu.version}" ]; then \
         libtiff5=${libtiff.version} \
         libtiff5-dev=${libtiff.version} \
         build-essential=${build.essential.version} && \
-      make -f Makefile-Linux-x86-64-gcc && \
+      make -f Makefile-Linux-$(uname -m)-gcc && \
       mkdir /build/kakadu/lib && \
       mkdir /build/kakadu/bin && \
-      cp ../lib/Linux-x86-64-gcc/*.so /build/kakadu/lib && \
-      cp ../bin/Linux-x86-64-gcc/kdu_compress /build/kakadu/bin && \
-      cp ../bin/Linux-x86-64-gcc/kdu_expand /build/kakadu/bin && \
-      cp ../bin/Linux-x86-64-gcc/kdu_jp2info /build/kakadu/bin ; \
+      cp ../lib/Linux-$(uname -m)-gcc/*.so /build/kakadu/lib && \
+      cp ../bin/Linux-$(uname -m)-gcc/kdu_compress /build/kakadu/bin && \
+      cp ../bin/Linux-$(uname -m)-gcc/kdu_expand /build/kakadu/bin && \
+      cp ../bin/Linux-$(uname -m)-gcc/kdu_jp2info /build/kakadu/bin ; \
     else \
       mkdir -p /build/kakadu/lib && \
       mkdir -p /build/kakadu/bin && \
@@ -122,7 +122,7 @@ RUN apt-get update -qq && \
     libperl5.34=${libperl.version} \
     < /dev/null > /dev/null && \
     mkdir -p /opt/libjpeg-turbo/lib && \
-    ln -s /usr/lib/x86_64-linux-gnu/libturbojpeg.so.0 /opt/libjpeg-turbo/lib/libturbojpeg.so && \
+    ln -s /usr/lib/$(uname -m)-linux-gnu/libturbojpeg.so.0 /opt/libjpeg-turbo/lib/libturbojpeg.so && \
     rm -rf /var/lib/apt/lists/*
 
 # Run Cantaloupe non-privileged


### PR DESCRIPTION
Building on my mac (M1) I only get an `arm64` build, and it does not work on intel machines. So I need to build with multi architectures. This PR enables that. (still testing)