### PR TITLE
[SERV-1032] Fix grok runtime by adding libperl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     <ffmpeg.version>7:4.4.2-0ubuntu0.22.04.1</ffmpeg.version>
     <python2.version>2.7.18-3</python2.version>
     <grok.version>11.0.0</grok.version>
+    <libperl.version>5.34.0-3ubuntu1.3</libperl.version>
 
     <!-- Java dependency versions -->
     <freelib.utils.version>3.0.1</freelib.utils.version>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -119,6 +119,7 @@ RUN apt-get update -qq && \
     curl=${curl.version} \
     ffmpeg=${ffmpeg.version} \
     python2=${python2.version} \
+    libperl5.34=${libperl.version} \
     < /dev/null > /dev/null && \
     mkdir -p /opt/libjpeg-turbo/lib && \
     ln -s /usr/lib/x86_64-linux-gnu/libturbojpeg.so.0 /opt/libjpeg-turbo/lib/libturbojpeg.so && \


### PR DESCRIPTION
We mistakenly removed perl awhile ago. This breaks grok. We need to add it back.

Fixes #165 