### PR TITLE
[SERV-1088] Fix security issues in Docker-Cantaloupe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,11 @@
 
   <properties>
     <!-- What versions of Cantaloupe and Kakadu are we using? -->
+    <!-- Currently the develop branch of Cantaloupe is not up to date with the latest release
+         causing security issues. Until the develop branch is updated, we will use the latest 
+         release commit # v5.0.6-->
     <cantaloupe.version>5.0.6</cantaloupe.version>
-    <cantaloupe.commit.ref></cantaloupe.commit.ref>
+    <cantaloupe.commit.ref>60c3e2bae4fa3458e1df29113172319fcd6102a3</cantaloupe.commit.ref>
     <cantaloupe.apply.patchfiles>false</cantaloupe.apply.patchfiles>
     <kakadu.version></kakadu.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   <properties>
     <!-- What versions of Cantaloupe and Kakadu are we using? -->
     <!-- Currently the develop branch of Cantaloupe is not up to date with the latest release
-         causing security issues. Until the develop branch is updated, we will use the latest 
+         causing security issues. Until the develop branch is updated, we will use the latest
          release commit # v5.0.6-->
     <cantaloupe.version>5.0.6</cantaloupe.version>
     <cantaloupe.commit.ref>60c3e2bae4fa3458e1df29113172319fcd6102a3</cantaloupe.commit.ref>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /build/cantaloupe
 COPY patches /build/cantaloupe-patches
 RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       git clone --quiet https://github.com/cantaloupe-project/cantaloupe.git . && \
+      git checkout -b 60c3e2bae4fa3458e1df29113172319fcd6102a3 60c3e2bae4fa3458e1df29113172319fcd6102a3;\
       \
       # We can supply a particular commit ref as a defense against a broken upstream
       if [ -n "${cantaloupe.commit.ref}" -a "${cantaloupe.commit.ref}" != "latest" ] ; then \

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /build/cantaloupe
 COPY patches /build/cantaloupe-patches
 RUN if [ "${cantaloupe.version}" = "dev" ] ; then \
       git clone --quiet https://github.com/cantaloupe-project/cantaloupe.git . && \
-      git checkout -b 60c3e2bae4fa3458e1df29113172319fcd6102a3 60c3e2bae4fa3458e1df29113172319fcd6102a3;\
       \
       # We can supply a particular commit ref as a defense against a broken upstream
       if [ -n "${cantaloupe.commit.ref}" -a "${cantaloupe.commit.ref}" != "latest" ] ; then \


### PR DESCRIPTION
Currently, we are using the Develop branch in the upstream Cantaloupe project that has not had security fixes for all of our docker images. The newest version of Cantaloupe, 5.0.6, has had most of the security issues fixed. Until Cantaloupe updates its Develop branch, Docker-Cantaloupe should use 5.0.6 to avoid security issues. 