### PR TITLE
[SERV-1092] Switch github secrets to variable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
           maven_args: >
             -Drevision=nightly
             -Dcantaloupe.version=dev
-            -Dcantaloupe.commit.ref=${{ secrets.DEV_COMMIT_REF }}
+            -Dcantaloupe.commit.ref=${{ vars.DEV_COMMIT_REF }}
             -Dcantaloupe.apply.patchfiles=${{ secrets.APPLY_PATCHFILES }}
             -ntp -Dorg.slf4j.simpleLogger.log.net.sourceforge.pmd=error
             -DskipNexusStagingDeployMojo=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,6 @@ jobs:
             -Ddocker.registry.username=${{ secrets.DOCKER_USERNAME }}
             -Ddocker.registry.account=${{ secrets.DOCKER_REGISTRY_ACCOUNT}}
             -Ddocker.registry.password=${{ secrets.DOCKER_PASSWORD }}
-            -Dcantaloupe.commit.ref=${{ secrets.DEV_COMMIT_REF }}
+            -Dcantaloupe.commit.ref=${{ vars.DEV_COMMIT_REF }}
             -Dcantaloupe.apply.patchfiles=${{ secrets.APPLY_PATCHFILES }}
             -Dcantaloupe.version=dev

--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,8 @@
 
   <properties>
     <!-- What versions of Cantaloupe and Kakadu are we using? -->
-    <!-- Currently the develop branch of Cantaloupe is not up to date with the latest release
-         causing security issues. Until the develop branch is updated, we will use the latest
-         release commit # v5.0.6-->
     <cantaloupe.version>5.0.6</cantaloupe.version>
-    <cantaloupe.commit.ref>60c3e2bae4fa3458e1df29113172319fcd6102a3</cantaloupe.commit.ref>
+    <cantaloupe.commit.ref></cantaloupe.commit.ref>
     <cantaloupe.apply.patchfiles>false</cantaloupe.apply.patchfiles>
     <kakadu.version></kakadu.version>
 


### PR DESCRIPTION
A previous bug was caused by patch files built upon a specific commit hash that was hidden by Github secrets. Since the commit hash was obscured by github secrets, we've decided to move certain secrets into variables, so that they are easier to debug in the future.
For now as we wait for security updates and other PRs to be merged with the base repo of Cantaloupe, the security issues will be present, and we will continue to use our patchfiles. 